### PR TITLE
Fix inference to not use ground truth latents

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The model is just a rewriting of original model : `Gaspard/Seq2Seq/models/transf
 
 We use the generated EEG embeddings from part 2 to generate predicted latents.
 
-Script : `Gaspard/Seq2Seq/inference_seq2seq.py`
+Script : `Gaspard/Seq2Seq/inference_seq2seq_v2.py`
 
 
 


### PR DESCRIPTION
## Summary
- remove ground truth latents from `inference_seq2seq_v2.py`
- implement autoregressive decoding
- update README reference to inference script

## Testing
- `python -m py_compile Gaspard/Seq2Seq/inference_seq2seq_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_68412314ce748328a9f3572b060ed028