### PR TITLE
Fix OUTPUT_DIR definition

### DIFF
--- a/EEG_preprocessing/segment_sliding_window.py
+++ b/EEG_preprocessing/segment_sliding_window.py
@@ -22,16 +22,17 @@ def seg_sliding_window(data, win_s, step_s, fs=200):
 
 
 if __name__ == "__main__":
-    
-    # Input and output directories
+
+    # Input directory
     INPUT_DIR = './data/Preprocessing/Segmented_Rawf_200Hz_2s'
-    OUTPUT_DIR = './data/Preprocessing/Segmented_{int(1000*WIN_S)}ms_sw'
-    
+
     # Segmenting settings
     FS = 200                  # fréquence d'échantillonnage (Hz)
     WIN_S = 0.5               # fenêtre (secondes)
     STEP_S = 0.25             # recouvrement (secondes)
-    
+
+    # Output directory depends on WIN_S
+    OUTPUT_DIR = f'./data/Preprocessing/Segmented_{int(1000*WIN_S)}ms_sw'
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
     for fname in os.listdir(INPUT_DIR):


### PR DESCRIPTION
## Summary
- fix the OUTPUT_DIR path to use WIN_S
- create the output directory once up front

## Testing
- `python -m py_compile EEG_preprocessing/segment_sliding_window.py`

------
https://chatgpt.com/codex/tasks/task_e_684123e135b88328b6c7a12bb59afe90