### PR TITLE
Persist scalers for GLMNet and semantic predictor

### DIFF
--- a/Gaspard/GLMNet/modules/utils_glmnet.py
+++ b/Gaspard/GLMNet/modules/utils_glmnet.py
@@ -20,14 +20,35 @@ class GLMNet(nn.Module):
         l_freq = self.freq_local(x_feat[:, self.occipital_idx, :])
         return self.fc(torch.cat([g_raw, l_freq], dim=1))
 
-def standard_scale_features(X):
-    # X: (N, features...)
-    # Flatten to 2D if needed
+def standard_scale_features(X, scaler=None, return_scaler=False):
+    """Scale features with ``StandardScaler``.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Array of shape ``(N, ...)`` to scale.
+    scaler : sklearn.preprocessing.StandardScaler or None
+        If ``None`` a new scaler is fitted on ``X``. Otherwise ``X`` is
+        transformed using the provided scaler.
+    return_scaler : bool, optional
+        Whether to return the fitted scaler.
+
+    Returns
+    -------
+    np.ndarray
+        Scaled array with the same shape as ``X``.
+    sklearn.preprocessing.StandardScaler, optional
+        Returned only if ``return_scaler`` is ``True``.
+    """
+
     orig_shape = X.shape[1:]
     X_2d = X.reshape(len(X), -1)
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X_2d)
-        
-    # Reshape back
-    X_scaled = X_scaled.reshape((len(X),) + orig_shape)
+
+    if scaler is None:
+        scaler = StandardScaler().fit(X_2d)
+
+    X_scaled = scaler.transform(X_2d).reshape((len(X),) + orig_shape)
+
+    if return_scaler:
+        return X_scaled, scaler
     return X_scaled

--- a/Gaspard/GLMNet/train_glmnet.py
+++ b/Gaspard/GLMNet/train_glmnet.py
@@ -5,8 +5,9 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
-import  wandb
+import wandb
 from torch.optim.lr_scheduler import ReduceLROnPlateau
+import pickle
 
 project_root = os.path.dirname(
     os.path.dirname(
@@ -97,7 +98,16 @@ def main():
         X_train, F_train, y_train = get_data(train_blocks)
         X_val, F_val, y_val = get_data([val_block])
         X_test, F_test, y_test = get_data([test_block])
-        F_train_scaled, F_val_scaled, F_test_scaled = standard_scale_features(F_train), standard_scale_features(F_val), standard_scale_features(F_test)
+
+        # Fit scaler on training features and apply to all splits
+        F_train_scaled, scaler = standard_scale_features(F_train, return_scaler=True)
+        F_val_scaled = standard_scale_features(F_val, scaler=scaler)
+        F_test_scaled = standard_scale_features(F_test, scaler=scaler)
+
+        # Save scaler for this fold
+        scaler_path = os.path.join(args.save_dir, f"{subj_name}_fold{test_block}_scaler.pkl")
+        with open(scaler_path, "wb") as f:
+            pickle.dump(scaler, f)
 
 
         # Conversion en tenseurs

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,7 +6,7 @@ from EEG_preprocessing.segment_raw_signals_200Hz import extract_2s_segment
 from EEG_preprocessing.segment_sliding_window import seg_sliding_window
 from EEG_preprocessing.extract_DE_PSD_features_1per500ms import extract_de_psd_sw
 from EEG_preprocessing.extract_DE_PSD_features_1per2s import extract_de_psd_raw
-from Gaspard.GLMNet.inference_glmnet import inf_glmnet, load_glmnet_from_checkpoint
+from Gaspard.GLMNet.inference_glmnet import inf_glmnet, load_glmnet_from_checkpoint, load_scaler
 from Gaspard.Seq2Seq.inference_seq2seq_v2 import inf_seq2seq, load_s2s_from_checkpoint
 from Gaspard.SemanticPredictor.inference_semantic import inf_semantic_predictor, load_semantic_predictor_from_checkpoint
 from Gaspard.TuneAVideo.inference_tuneavideo import inf_tuneavideo, load_tuneavideo_from_checkpoint, load_pairs
@@ -25,8 +25,10 @@ def parse_args():
     
     # Define model checkpoints to use
     parser.add_argument("--glmnet_path", type=str, default="./Gaspard/checkpoints/glmnet/sub3_fold0_best.pt", help="Path to GLMNet model checkpoint")
+    parser.add_argument("--glmnet_scaler_path", type=str, default="./Gaspard/checkpoints/glmnet/sub3_fold0_scaler.pkl", help="Path to GLMNet StandardScaler")
     parser.add_argument("--s2s_path", type=str, default="./Gaspard/checkpoints/seq2seq/seq2seq_v2_classic.pth", help="Path to Seq2Seq model checkpoint")
     parser.add_argument("--sempred_path", type=str, default="./Gaspard/checkpoints/semantic/eeg2text_clip.pt", help="Path to Semantic Predictor model checkpoint")
+    parser.add_argument("--sempred_scaler_path", type=str, default="./Gaspard/checkpoints/semantic/scaler.pkl", help="Path to Semantic Predictor StandardScaler")
     parser.add_argument("--tuneavideo_path", type=str,default="./Gaspard/checkpoints/TuneAVideo/unet_ep89.pt",help="Path to TuneAVideo model checkpoint")
     
     # TuneAVideo parameters
@@ -65,7 +67,8 @@ if __name__ == "__main__":
     
     # GLMNet inference
     model_glmnet = load_glmnet_from_checkpoint(args.glmnet_path, device=DEVICE)
-    eeg_embeddings = inf_glmnet(model_glmnet, seven_sw, features_seven_sw, device=DEVICE)[None, None, None, ...]
+    scaler_glmnet = load_scaler(args.glmnet_scaler_path)
+    eeg_embeddings = inf_glmnet(model_glmnet, scaler_glmnet, seven_sw, features_seven_sw, device=DEVICE)[None, None, None, ...]
     print("EEG embeddings shape:", eeg_embeddings.shape)
     
     # Seq2Seq inference
@@ -75,7 +78,8 @@ if __name__ == "__main__":
     
     # Semantic Predictor inference
     model_semantic = load_semantic_predictor_from_checkpoint(args.sempred_path, device=DEVICE)
-    sem_embeddings = inf_semantic_predictor(model_semantic, features_raw[0], device=DEVICE)
+    scaler_semantic = load_scaler(args.sempred_scaler_path)
+    sem_embeddings = inf_semantic_predictor(model_semantic, scaler_semantic, features_raw[0], device=DEVICE)
     print("Semantic embeddings shape:", sem_embeddings.shape)
     
     # TuneAvideo inference    


### PR DESCRIPTION
## Summary
- allow `standard_scale_features` to reuse an existing scaler
- save fitted scaler per fold when training GLMNet
- load saved scaler in GLMNet inference and pipeline
- save and reuse scaler for Semantic Predictor
- adapt pipeline and inference scripts to new arguments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841817614308328ba640ebfc7fe99be