### PR TITLE
Fix scheduler metric

### DIFF
--- a/Gaspard/GLMNet/train_glmnet.py
+++ b/Gaspard/GLMNet/train_glmnet.py
@@ -172,7 +172,7 @@ def main():
                     xb, xf, yb = xb.to(device), xf.to(device), yb.to(device)
                     pred = model(xb, xf); va += (pred.argmax(1) == yb).sum().item()
             val_acc = va / len(ds_val)
-            scheduler.step(train_acc)
+            scheduler.step(val_acc)
 
             if val_acc > best_val:
                 best_val = val_acc


### PR DESCRIPTION
## Summary
- update GLMNet trainer to step the scheduler with validation accuracy

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684520848e3c8328b8c8ae8dd940092b