### PR TITLE
Add raw EEG normalization

### DIFF
--- a/Gaspard/GLMNet/inference_glmnet.py
+++ b/Gaspard/GLMNet/inference_glmnet.py
@@ -10,7 +10,11 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
     
 
-from Gaspard.GLMNet.modules.utils_glmnet import GLMNet, standard_scale_features
+from Gaspard.GLMNet.modules.utils_glmnet import (
+    GLMNet,
+    standard_scale_features,
+    normalize_raw,
+)
 
 
 OCCIPITAL_IDX = list(range(50, 62))  # 12 occipital channels
@@ -28,7 +32,12 @@ def load_scaler(scaler_path):
         return pickle.load(f)
 
 
-def inf_glmnet(model, scaler, raw_sw, feat_sw, device='cuda'):
+def load_raw_stats(path):
+    data = np.load(path)
+    return data["mean"], data["std"]
+
+
+def inf_glmnet(model, scaler, raw_sw, feat_sw, stats, device='cuda'):
        
     # verify consistency
     assert raw_sw.shape[:4] == feat_sw.shape[:4], \
@@ -37,6 +46,8 @@ def inf_glmnet(model, scaler, raw_sw, feat_sw, device='cuda'):
     # flatten for batch inference
     raw_flat = raw_sw.reshape(-1, raw_sw.shape[-2], raw_sw.shape[-1])
     feat_flat = feat_sw.reshape(-1, feat_sw.shape[-2], feat_sw.shape[-1])
+
+    raw_flat = normalize_raw(raw_flat, stats[0], stats[1])
 
     # scale features
     feat_scaled = standard_scale_features(feat_flat, scaler=scaler)
@@ -53,10 +64,11 @@ def inf_glmnet(model, scaler, raw_sw, feat_sw, device='cuda'):
     return np.stack(embeddings)  # shape: (N_segments, emb_dim*2)
 
 # --- Main generation loop ---
-def generate_all_embeddings(raw_dir, feat_dir, ckpt_path, scaler_path, output_dir, device='cuda'):
+def generate_all_embeddings(raw_dir, feat_dir, ckpt_path, scaler_path, stats_path, output_dir, device='cuda'):
     os.makedirs(output_dir, exist_ok=True)
 
     scaler = load_scaler(scaler_path)
+    stats = load_raw_stats(stats_path)
 
     for fname in os.listdir(raw_dir):
         if not (fname.endswith('.npy') and fname.startswith('sub3')):
@@ -69,7 +81,7 @@ def generate_all_embeddings(raw_dir, feat_dir, ckpt_path, scaler_path, output_di
         FEAT_SW = np.load(os.path.join(feat_dir, fname))
         # expect shape: (7, 40, 5, 7, 62, 100) and (7, 40, 5, 7, 62, 5)
         model = load_glmnet_from_checkpoint(ckpt_path, device)
-        embeddings = inf_glmnet(model, scaler, RAW_SW, FEAT_SW, device)
+        embeddings = inf_glmnet(model, scaler, RAW_SW, FEAT_SW, stats, device)
         
         out_path = os.path.join(output_dir, f"{subj}.npy")
         np.save(out_path, embeddings)
@@ -83,6 +95,14 @@ if __name__ == "__main__":
     parser.add_argument('--feat_dir', default="./data/Preprocessing/DE_500ms_sw", help='directory of pre-windowed feature .npy files')
     parser.add_argument('--checkpoint_path', default="./Gaspard/checkpoints/glmnet/sub3_fold0_color_best.pt", help='path to GLMNet checkpoint')
     parser.add_argument('--scaler_path', default="./Gaspard/checkpoints/glmnet/sub3_fold0_color_scaler.pkl", help='path to saved StandardScaler')
+    parser.add_argument('--stats_path', default="./Gaspard/checkpoints/glmnet/sub3_fold0_color_rawnorm.npz", help='path to raw EEG normalization stats')
     parser.add_argument('--output_dir', default="./data/GLMNet/EEG_embeddings_sw", help='where to save concatenated embeddings')
     args = parser.parse_args()
-    generate_all_embeddings(args.raw_dir, args.feat_dir, args.checkpoint_path, args.scaler_path, args.output_dir)
+    generate_all_embeddings(
+        args.raw_dir,
+        args.feat_dir,
+        args.checkpoint_path,
+        args.scaler_path,
+        args.stats_path,
+        args.output_dir,
+    )

--- a/Gaspard/GLMNet/modules/utils_glmnet.py
+++ b/Gaspard/GLMNet/modules/utils_glmnet.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn as nn
 from Gaspard.GLMNet.modules.models_paper import shallownet, mlpnet
-from sklearn.preprocessing import StandardScaler 
+from sklearn.preprocessing import StandardScaler
+import numpy as np
 
 class GLMNet(nn.Module):
     """ShallowNet (raw) + MLP (freq) → concat → FC."""
@@ -89,3 +90,15 @@ def standard_scale_features(X, scaler=None, return_scaler=False):
     if return_scaler:
         return X_scaled, scaler
     return X_scaled
+
+
+def compute_raw_stats(X: np.ndarray):
+    """Compute per-channel mean and std from training data."""
+    mean = X.mean(axis=(0, 2))
+    std = X.std(axis=(0, 2)) + 1e-6
+    return mean, std
+
+
+def normalize_raw(X: np.ndarray, mean: np.ndarray, std: np.ndarray):
+    """Normalize raw EEG with provided statistics."""
+    return (X - mean[None, :, None]) / std[None, :, None]

--- a/README.md
+++ b/README.md
@@ -85,11 +85,15 @@ We use 2s raw EEGs and 1s windows for DE/PSD features.
 
 Script : `Gaspard/GLMNet/train_glmnet.py`
 
+- Raw EEGs are normalized per channel using the training split statistics.
+
 ### Inference :
     
 We generate EEgs embeddings from train GLMNet.
 
 We use 2s raw EEGs and 500ms windows for DE/PSD features.
+
+The same normalization parameters are loaded to preprocess raw EEGs at inference time.
 
 Script : `Gaspard/GLMNet/inference_glmnet.py`
 


### PR DESCRIPTION
## Summary
- compute and apply per-channel normalization for raw EEG
- save normalization parameters and use them in inference pipeline
- document normalization procedure in README

## Testing
- `python -m py_compile Gaspard/GLMNet/modules/utils_glmnet.py Gaspard/GLMNet/train_glmnet.py Gaspard/GLMNet/inference_glmnet.py pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6846bed4c05483288c232373a7c11a8a