### PR TITLE
Restrict EEG model training to 500ms windows

### DIFF
--- a/Gaspard/GLMNet/train_glfnet_mlp.py
+++ b/Gaspard/GLMNet/train_glfnet_mlp.py
@@ -30,7 +30,7 @@ OCCIPITAL_IDX = list(range(50, 62))
 
 def parse_args():
     p = argparse.ArgumentParser()
-    p.add_argument("--feat_dir", default="./data/Preprocessing/DE_1per1s/", help="directory with .npy files")
+    p.add_argument("--feat_dir", default="./data/Preprocessing/DE_500ms_sw", help="directory with .npy files")
     p.add_argument("--label_dir", default="./data/meta_info", help="Label file")
     p.add_argument(
         "--category",
@@ -62,8 +62,8 @@ def parse_args():
     p.add_argument("--use_wandb", action="store_true")
     p.add_argument(
         "--window",
-        choices=["1s", "500ms"],
-        default="1s",
+        choices=["500ms"],
+        default="500ms",
         help="length of EEG windows used for training",
     )
     return p.parse_args()
@@ -99,8 +99,6 @@ def format_labels(labels: np.ndarray, category: str) -> np.ndarray:
 
 def main():
     args = parse_args()
-    if args.window == "500ms" and args.feat_dir == "./data/Preprocessing/DE_1per1s/":
-        args.feat_dir = "./data/Preprocessing/DE_500ms_sw"
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"Using device: {device}")
 
@@ -110,14 +108,8 @@ def main():
     subj_name = filename.replace(".npy", "")
 
     feat = np.load(os.path.join(args.feat_dir, filename))
-    if args.window == "1s":
-        if feat.ndim == 5:
-            feat = np.repeat(feat[:, :, :, None, :, :], 2, axis=3)
-        n_win = 2
-        assert feat.ndim == 6 and feat.shape[:4] == (7, 40, 5, n_win), "Unexpected feature shape"
-    else:
-        n_win = feat.shape[3]
-        assert feat.ndim == 6 and feat.shape[:4] == (7, 40, 5, n_win), "Unexpected feature shape"
+    n_win = feat.shape[3]
+    assert feat.ndim == 6 and feat.shape[:4] == (7, 40, 5, n_win), "Unexpected feature shape"
 
     labels_raw = np.load(f"{args.label_dir}/All_video_{args.category}.npy")
     unique_labels, counts_labels = np.unique(labels_raw, return_counts=True)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,7 @@ We detect on 3 types of windows :
 
     Script : `EEG_preprocessing/extract_DE_PSD_features_1per2s.py`
 
-- Detect features on 1s windows without overlapping.
-
-    Shapes adapted to (block, concept, repetition, window, channel, band).
-
-    Script : `EEG_preprocessing/extract_DE_PSD_features_1per1s.py`
-
-- Detect features on 1s windows without overlapping.
+- Detect features on 500ms windows with a 250 ms overlap.
 
     Shapes adapted to (block, concept, repetition, window, channel, band).
 
@@ -81,9 +75,8 @@ Models path : `Gaspard/GLMNet/models.py`
 
 ### Training :
 
-Training uses 2s raw EEGs and 1&nbsp;s windows for DE/PSD features by default. Pass
-`--window 500ms` to instead use the 500&nbsp;ms sliding‑window data stored in
-`Segmented_500ms_sw` and `DE_500ms_sw`.
+Training uses 2s raw EEGs split into 500&nbsp;ms sliding windows for DE/PSD features.
+The pre‑segmented data is stored in `Segmented_500ms_sw` and `DE_500ms_sw`.
 
 Script : `Gaspard/GLMNet/train_glmnet.py`
 
@@ -94,8 +87,6 @@ trained with `Gaspard/GLMNet/train_glfnet_mlp.py`.
 - Both trainers accept a `--scheduler` argument (`steplr`,
   `reducelronplateau`, `cosine`) and a `--min_lr` value to set the learning rate
   floor.
-- Use `--window 500ms` to train on the 500&nbsp;ms sliding windows instead of the
-  default 1&nbsp;s segments.
 
 ### Inference :
     


### PR DESCRIPTION
## Summary
- limit `train_glmnet` and `train_glfnet_mlp` to 500 ms windows only
- update dataset defaults for new window size
- clean README of outdated 1 s instructions

## Testing
- `python -m py_compile Gaspard/GLMNet/train_glmnet.py Gaspard/GLMNet/train_glfnet_mlp.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847ddf1eba4832899abd2f0003f1063