### PR TITLE
Add multi-subject support and cluster filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ trained with `EEG2Video/GLMNet/train_glfnet_mlp.py`.
 - Both trainers accept a `--scheduler` argument (`steplr`,
   `reducelronplateau`, `cosine`) and a `--min_lr` value to set the learning rate
   floor.
+- `train_glmnet.py` can load several subjects at once with `--subjects`
+  (e.g. `--subjects sub3.npy sub4.npy`) and allows filtering the dataset
+  with `--cluster-id` to keep only samples belonging to a given label cluster.
 
 ### Inference :
     


### PR DESCRIPTION
## Summary
- extend `train_glmnet.py` with `--subjects` argument for loading multiple files
- add optional `--cluster-id` filter
- concatenate data from all subjects before random split
- document the new options in the README

## Testing
- `python -m py_compile EEG2Video/GLMNet/train_glmnet.py`

------
https://chatgpt.com/codex/tasks/task_e_6850fa1f13648328a887dee30f1dfbcd