### PR TITLE
Save ShallowNet weights

### DIFF
--- a/EEG2Video/GLMNet/train_glmnet.py
+++ b/EEG2Video/GLMNet/train_glmnet.py
@@ -85,10 +85,14 @@ def main():
     print(f"Using device: {device}")
     
     os.makedirs(args.save_dir, exist_ok=True)
-    
+
     # Sélection d’un seul sujet
     filename = "sub3.npy"  # ou args.subj_name
     subj_name = filename.replace(".npy", "")
+
+    shallownet_path = os.path.join(
+        args.save_dir, f"{subj_name}_{args.category}_shallownet.pt"
+    )
 
     raw = np.load(os.path.join(args.raw_dir, filename))
     feat = np.load(os.path.join(args.feat_dir, filename))
@@ -209,8 +213,14 @@ def main():
         if val_acc > best_val:
             best_val = val_acc
             os.makedirs(args.save_dir, exist_ok=True)
-            torch.save(model.state_dict(), f"{args.save_dir}/{subj_name}_{args.category}_best.pt")
-            print(f"New best model saved at epoch {ep} with val_acc={val_acc:.3f}")
+            torch.save(
+                model.state_dict(),
+                f"{args.save_dir}/{subj_name}_{args.category}_best.pt",
+            )
+            torch.save(model.raw_global.state_dict(), shallownet_path)
+            print(
+                f"New best model saved at epoch {ep} with val_acc={val_acc:.3f}"
+            )
 
         if args.use_wandb:
             wandb.log({"epoch": ep, "train/acc": train_acc, "val/acc": val_acc,

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ trained with `EEG2Video/GLMNet/train_glfnet_mlp.py`.
   `reducelronplateau`, `cosine`) and a `--min_lr` value to set the learning rate
   floor.
 
+- The best checkpoint is saved as `<subject>_<category>_best.pt` and the
+  ShallowNet weights are also stored in
+  `<subject>_<category>_shallownet.pt`.
+
 ### Inference :
     
 We generate EEgs embeddings from train GLMNet.


### PR DESCRIPTION
## Summary
- save ShallowNet branch weights while training GLMNet
- mention the new file in the docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853e50c6b00832880e4a1a434cddb49