### PR TITLE
Add EEG backbone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Script : `EEG2Video/Seq2Seq/inference_seq2seq_v2.py`
 - During inference, provide the same `--stats_path` to restore latents to their original scale.
 
 Autoregressive variant:
-- Training script: `EEG2Video/Seq2Seq/train_my_autoregressive_transformer.py` with option `--save_scaler` to store the fitted scaler (e.g. `scaler.pkl`).
-- Inference script: `EEG2Video/Seq2Seq/inference_my_autoregressive_transformer.py` with option `--scaler_path` to load this scaler.
+- Training script: `EEG2Video/Seq2Seq/train_my_autoregressive_transformer.py` with option `--save_scaler` to store the fitted scaler (e.g. `scaler.pkl`). Use `--eeg_backbone` to choose between `eegnet` and `shallownet`, and optionally provide `--shallownet_ckpt` for pretrained ShallowNet weights.
+- Inference script: `EEG2Video/Seq2Seq/inference_my_autoregressive_transformer.py` with option `--scaler_path` to load this scaler. The same `--eeg_backbone` and `--shallownet_ckpt` options ensure consistent EEG encoding during prediction.
 
 
 


### PR DESCRIPTION
## Summary
- add an optional ShallowNet EEG encoder
- expose `--eeg_backbone` and `--shallownet_ckpt` in training & inference
- document new options in comments and docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e512e2008328819a0a1ed69ead7b