### PR TITLE
Add selective feature computation for DE_PSD

### DIFF
--- a/EEG2Video/GLMNet/modules/utils_glmnet.py
+++ b/EEG2Video/GLMNet/modules/utils_glmnet.py
@@ -68,7 +68,7 @@ class GLMNet(nn.Module):
         """Compute DE features from raw EEG."""
         feats = np.zeros((raw.shape[0], raw.shape[1], 5), dtype=np.float32)
         for i, seg in enumerate(raw):
-            de, _ = DE_PSD(seg, fs, win_sec)
+            de = DE_PSD(seg, fs, win_sec, which="de")
             feats[i] = de
         return feats
 

--- a/EEG_preprocessing/extract_DE_PSD_features_1per1s.py
+++ b/EEG_preprocessing/extract_DE_PSD_features_1per1s.py
@@ -43,8 +43,8 @@ for subname in sub_list:
             de_class_data = np.empty((0, 2, 62, 5))
             psd_class_data = np.empty((0, 2, 62, 5))
             for i in range(5):
-                de1, psd1 = DE_PSD(now_data[class_id, i, :, :200].reshape(62, fre), fre, 1)
-                de2, psd2 = DE_PSD(now_data[class_id, i, :, 200:].reshape(62, fre), fre, 1)
+                de1, psd1 = DE_PSD(now_data[class_id, i, :, :200].reshape(62, fre), fre, 1, which="both")
+                de2, psd2 = DE_PSD(now_data[class_id, i, :, 200:].reshape(62, fre), fre, 1, which="both")
                 de_class_data = np.concatenate((de_class_data, np.concatenate((de1.reshape(1, 62, 5), de2.reshape(1, 62, 5))).reshape(1, 2, 62, 5)))
                 psd_class_data = np.concatenate((psd_class_data, np.concatenate((psd1.reshape(1, 62, 5), psd2.reshape(1, 62, 5))).reshape(1, 2, 62, 5)))
             de_block_data = np.concatenate((de_block_data, de_class_data.reshape(1, 5, 2, 62, 5)))

--- a/EEG_preprocessing/extract_DE_PSD_features_1per2s.py
+++ b/EEG_preprocessing/extract_DE_PSD_features_1per2s.py
@@ -21,7 +21,7 @@ def extract_de_psd_raw(raw,fs=200):
         for cls in range(raw.shape[1]):
             for rep in range(raw.shape[2]):
                 segment = raw[blk, cls, rep, :, :].reshape(raw.shape[3], 2*fre)
-                de,psd = DE_PSD(segment, fs, 2) # 2 sec
+                de, psd = DE_PSD(segment, fs, 2, which="both")  # 2 sec
                 DE_data[blk, cls, rep]  = de  # (62,5)
                 PSD_data[blk, cls, rep] = psd # (62,5)
                 

--- a/EEG_preprocessing/extract_DE_PSD_features_1per500ms.py
+++ b/EEG_preprocessing/extract_DE_PSD_features_1per500ms.py
@@ -22,7 +22,7 @@ def extract_de_psd_sw(raw, fs,win_sec):
             for rep in range(raw.shape[2]):
                 for win in range(raw.shape[3]):
                     segment = raw[blk, cls, rep, win, :, :]  # (62, 100)
-                    de, psd = DE_PSD(segment, fs, win_sec)
+                    de, psd = DE_PSD(segment, fs, win_sec, which="both")
                     DE_data[blk, cls, rep, win]  = de  # (62,5)
                     PSD_data[blk, cls, rep, win] = psd # (62,5)
 


### PR DESCRIPTION
## Summary
- add `which` parameter to `DE_PSD` to compute DE, PSD or both
- update feature extraction scripts to pass the new argument
- adjust GLMNet utilities to request only DE features

## Testing
- `python -m py_compile EEG_preprocessing/DE_PSD.py EEG_preprocessing/extract_DE_PSD_features_1per1s.py EEG_preprocessing/extract_DE_PSD_features_1per2s.py EEG_preprocessing/extract_DE_PSD_features_1per500ms.py EEG2Video/GLMNet/modules/utils_glmnet.py`


------
https://chatgpt.com/codex/tasks/task_e_685931799dec8328a267543dbb286a91