### PR TITLE
Move spectral feature computation to mlpnet

### DIFF
--- a/EEG2Video/GLMNet/inference_glmnet.py
+++ b/EEG2Video/GLMNet/inference_glmnet.py
@@ -16,6 +16,7 @@ from EEG2Video.GLMNet.modules.utils_glmnet import (
     load_scaler,
     load_raw_stats,
 )
+from EEG2Video.GLMNet.modules.models_paper import mlpnet
 
 
 OCCIPITAL_IDX = list(range(50, 62))  # 12 occipital channels
@@ -25,7 +26,7 @@ def inf_glmnet(model, scaler, raw_sw, stats, device="cuda"):
 
     # always compute spectral features from the raw windows
     raw_flat = raw_sw.reshape(-1, raw_sw.shape[-2], raw_sw.shape[-1])
-    feat_sw = GLMNet.compute_features(raw_flat)
+    feat_sw = mlpnet.compute_features(raw_flat)
     # reshape back to (runs, videos, trials, windows, channels, features)
     feat_sw = feat_sw.reshape(raw_sw.shape[:-2] + feat_sw.shape[-2:])
 

--- a/EEG2Video/GLMNet/modules/models_paper.py
+++ b/EEG2Video/GLMNet/modules/models_paper.py
@@ -16,6 +16,7 @@ import itertools
 import datetime
 import time
 import numpy as np
+from EEG_preprocessing.DE_PSD import DE_PSD
 
 import torch
 import torch.nn as nn
@@ -387,6 +388,15 @@ class mlpnet(nn.Module):
             nn.GELU(),
             nn.Linear(256, out_dim)
         )
+
+    @staticmethod
+    def compute_features(raw: np.ndarray, fs: int = 200, win_sec: float = 0.5) -> np.ndarray:
+        """Compute DE features from raw EEG."""
+        feats = np.zeros((raw.shape[0], raw.shape[1], 5), dtype=np.float32)
+        for i, seg in enumerate(raw):
+            de = DE_PSD(seg, fs, win_sec, which="de")
+            feats[i] = de
+        return feats
         
     def forward(self, x):               #input:(batch,C,5)
         out = self.net(x)

--- a/EEG2Video/GLMNet/modules/utils_glmnet.py
+++ b/EEG2Video/GLMNet/modules/utils_glmnet.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 from EEG2Video.GLMNet.modules.models_paper import shallownet, mlpnet
 from sklearn.preprocessing import StandardScaler
 import numpy as np
-from EEG_preprocessing.DE_PSD import DE_PSD
 import pickle
 
 class GLMNet(nn.Module):
@@ -64,14 +63,6 @@ class GLMNet(nn.Module):
         model.eval()
         return model
 
-    @staticmethod
-    def compute_features(raw: np.ndarray, fs: int = 200, win_sec: float = 0.5) -> np.ndarray:
-        """Compute DE features from raw EEG."""
-        feats = np.zeros((raw.shape[0], raw.shape[1], 5), dtype=np.float32)
-        for i, seg in enumerate(raw):
-            de = DE_PSD(seg, fs, win_sec, which="de")
-            feats[i] = de
-        return feats
 
     def forward(self, x_raw, x_feat, return_features: bool = False):
         """Forward pass of the network.

--- a/EEG2Video/GLMNet/train_glmnet.py
+++ b/EEG2Video/GLMNet/train_glmnet.py
@@ -27,6 +27,7 @@ from EEG2Video.GLMNet.modules.utils_glmnet import (
     load_scaler,
     load_raw_stats,
 )
+from EEG2Video.GLMNet.modules.models_paper import mlpnet
 
 
 # -------- W&B -------------------------------------------------------------
@@ -101,7 +102,7 @@ def main():
 
     raw = np.load(os.path.join(args.raw_dir, filename))
     # compute DE features from raw EEG windows
-    feat = GLMNet.compute_features(
+    feat = mlpnet.compute_features(
         raw.reshape(-1, raw.shape[-2], raw.shape[-1])
     ).reshape(*raw.shape[:4], raw.shape[-2], -1)
     

--- a/EEG2Video/Seq2Seq/models/my_autoregressive_transformer.py
+++ b/EEG2Video/Seq2Seq/models/my_autoregressive_transformer.py
@@ -107,7 +107,7 @@ class GLMNetEmbedding(nn.Module):
     def forward(self, x_raw: torch.Tensor) -> torch.Tensor:
         raw_np = x_raw.cpu().numpy()
         raw_np = raw_np.squeeze(1) if raw_np.ndim == 4 else raw_np
-        feat_np = self.model.compute_features(raw_np, fs=200, win_sec=self.T / 200)
+        feat_np = mlpnet.compute_features(raw_np, fs=200, win_sec=self.T / 200)
         raw_norm = normalize_raw(raw_np, self.raw_mean, self.raw_std)
         feat_scaled = standard_scale_features(feat_np, scaler=self.scaler)
         x_raw_t = torch.from_numpy(raw_norm).unsqueeze(1).to(x_raw.device)


### PR DESCRIPTION
## Summary
- move the `compute_features` helper from `GLMNet` to `mlpnet`
- update training and inference scripts to use `mlpnet.compute_features`
- adjust Seq2Seq model to call the new location

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_685a334ff6fc8328ae8d07b0f5a15fad