### PR TITLE
Normalize GLMNet branch embeddings

### DIFF
--- a/EEG2Video/GLMNet/modules/utils_glmnet.py
+++ b/EEG2Video/GLMNet/modules/utils_glmnet.py
@@ -80,6 +80,14 @@ class GLMNet(nn.Module):
 
         g_raw = self.raw_global(x_raw)
         l_freq = self.freq_local(x_feat[:, self.occipital_idx, :])
+
+        # Match frequency branch statistics to the raw branch
+        g_mean = g_raw.mean(dim=1, keepdim=True)
+        g_std = g_raw.std(dim=1, keepdim=True) + 1e-6
+        f_mean = l_freq.mean(dim=1, keepdim=True)
+        f_std = l_freq.std(dim=1, keepdim=True) + 1e-6
+        l_freq = (l_freq - f_mean) / f_std * g_std + g_mean
+
         features = torch.cat([g_raw, l_freq], dim=1)
 
         if return_features:


### PR DESCRIPTION
## Summary
- match the frequency branch statistics to the raw branch before concatenation

## Testing
- `flake8`
- `python -m py_compile EEG2Video/GLMNet/modules/utils_glmnet.py`

------
https://chatgpt.com/codex/tasks/task_e_685cdc9f24b88328a40c2814c66f6908