### PR TITLE
Resolve PatchEmbedding name conflict

### DIFF
--- a/EEGtoVideo/GLMNet/modules/models_paper.py
+++ b/EEGtoVideo/GLMNet/modules/models_paper.py
@@ -28,7 +28,8 @@ from einops import rearrange
 from einops.layers.torch import Rearrange, Reduce
 from einops import rearrange
 
-class PatchEmbedding(nn.Module):
+# Legacy feature extractor using several CNN variants.
+class EEGFeatureExtractor(nn.Module):
     def __init__(self, emb_size=40):
         # self.patch_size = patch_size
         super().__init__()
@@ -214,6 +215,7 @@ class tsconv(nn.Module):
 
 # Convolution module
 # use conv to capture local features, instead of postion embedding.
+# Extracts patch tokens from EEG signals for the Transformer encoder.
 class PatchEmbedding(nn.Module):
     def __init__(self, emb_size=40):
         # self.patch_size = patch_size


### PR DESCRIPTION
## Summary
- rename the first PatchEmbedding definition to `EEGFeatureExtractor`
- clarify the purpose of the remaining PatchEmbedding implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864c8df293c832880c2c7959d321e24