### PR TITLE
Add latent projector to GLMNet and update inference

### DIFF
--- a/EEGtoVideo/GLMNet/inference_glmnet.py
+++ b/EEGtoVideo/GLMNet/inference_glmnet.py
@@ -48,7 +48,7 @@ def inf_glmnet(model, scaler, raw_sw, stats, device="cuda"):
             z = model(x_raw, x_feat, return_features=True)
             embeddings.append(z.squeeze(0).cpu().numpy())
 
-    return np.stack(embeddings)  # shape: (N_segments, emb_dim*2)
+    return np.stack(embeddings)  # shape: (N_segments, emb_dim // 2)
 
 # --- Main generation loop ---
 def generate_all_embeddings(
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     
     parser.add_argument('--raw_dir', default="./data/Preprocessing/Segmented_500ms_sw", help='directory of pre-windowed raw EEG .npy files')
     parser.add_argument('--checkpoint_path', default="./EEGtoVideo/checkpoints/glmnet/sub3_label_cluster", help='path to GLMNet checkpoint')
-    parser.add_argument('--output_dir', default="./data/GLMNet/EEG_embeddings_sw", help='where to save concatenated embeddings')
+    parser.add_argument('--output_dir', default="./data/eeg_segments", help='where to save projected embeddings')
     args = parser.parse_args()
     generate_all_embeddings(
         args.raw_dir,


### PR DESCRIPTION
## Summary
- add 512→256 projection layer in `utils_glmnet.GLmNet`
- update checkpoint loading logic for the new layer
- modify forward pass to return projected features
- adjust inference script to save projected 256d latents in `data/eeg_segments`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661cf972108328919776837935eab9