### PR TITLE
Ajout utilitaire pour regrouper les paires

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Video clips are converted into 2-second GIFs and encoded with the VAE from Stabl
 
 ## 4. Pair Creation
 EEG embeddings and video latents share the same block/concept/repetition identifiers. We serialize these pairs in `npz` archives to feed them into the Transformer.
+A utility `utils/pairs_to_torch.py` loads every archive from `data/latent_pairs/`,
+stacks the `eeg_latent` and `video_latent` arrays and saves them in a single
+`torch` file with the keys `src` and `tgt`.
 
 ## 5. Transformer Training
 The Transformer takes EEG embeddings as input and predicts the corresponding video latent. Training scripts build upon the `EEGtoVideo/GLMNet` utilities and stream the paired data.

--- a/utils/pairs_to_torch.py
+++ b/utils/pairs_to_torch.py
@@ -1,0 +1,51 @@
+"""Gather latent pair archives into a single torch file."""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+
+
+def load_all_pairs(pair_dir: str) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load every ``npz`` in ``pair_dir`` and concatenate their contents."""
+    eeg_list = []
+    vid_list = []
+    pair_files = []
+    for root, _, files in os.walk(pair_dir):
+        for name in files:
+            if name.endswith(".npz"):
+                pair_files.append(os.path.join(root, name))
+
+    for path in tqdm(pair_files, desc="Loading pairs"):
+        with np.load(path) as data:
+            eeg_list.append(torch.from_numpy(data["eeg_latent"]))
+            vid_list.append(torch.from_numpy(data["video_latent"]))
+
+    src = torch.cat(eeg_list, dim=0)
+    tgt = torch.cat(vid_list, dim=0)
+    return src, tgt
+
+
+def save_torch_dataset(pair_dir: str, out_path: str) -> None:
+    """Save stacked latents from ``pair_dir`` into ``out_path``."""
+    src, tgt = load_all_pairs(pair_dir)
+    torch.save({"src": src.float(), "tgt": tgt.float()}, out_path)
+
+
+
+def main() -> None:
+    import argparse
+
+    p = argparse.ArgumentParser(description="Convert latent pair npz files to a torch archive")
+    p.add_argument("--pair_dir", default="./data/latent_pairs", help="directory containing npz pairs")
+    p.add_argument("--out", default="./data/pairs.pt", help="output torch file")
+    args = p.parse_args()
+
+    save_torch_dataset(args.pair_dir, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Résumé
- script `utils/pairs_to_torch.py` pour agréger les fichiers `npz` en un seul fichier `torch`
- explication de cette étape ajoutée dans le README

## Tests
- `python -m py_compile utils/pairs_to_torch.py`
- `python utils/pairs_to_torch.py --help` *(échoue: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686622753aa4832883ba78fb2cfef5bb