### PR TITLE
Add pair generation target and dataset path option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: p0 p1 p2
+.PHONY: p0 p1 p2 pairs
 
 # Pass additional options with ARGS
 
@@ -6,8 +6,13 @@
 p0:
 	python EEGtoVideo/GLMNet/train_glmnet.py $(ARGS)
 
+# Build npz/torch latent pairs
+pairs:
+	python utils/build_pairs.py $(ARGS)
+	python utils/pairs_to_torch.py $(ARGS)
+
 # P1: train Transformer with VAE and diffusion frozen
-p1:
+p1: pairs
 	python scripts/train_transformer.py --freeze_vae --freeze_diffuser $(ARGS)
 
 # P2: fine-tune end-to-end at low learning rate


### PR DESCRIPTION
## Summary
- add `pairs` target in Makefile running build and conversion steps
- call this target before running `p1`
- allow `scripts/train_transformer.py` to accept a dataset file or folder via `--data` (default `data/pairs.pt`)
- update dataset class to read `.pt` archives or `npz` files

## Testing
- `make -n pairs`
- `make -n p1`
- `python -m py_compile scripts/train_transformer.py`
- `python scripts/train_transformer.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6866272367588328a8c127815009fece