### PR TITLE
Specify Transformer pair directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ p0:
 
 # P1: train Transformer with VAE and diffusion frozen
 p1:
-	python scripts/train_transformer.py --freeze_vae --freeze_diffuser $(ARGS)
+	python scripts/train_transformer.py --data ./data/latent_pairs \
+	        --freeze_vae --freeze_diffuser $(ARGS)
 
 # P2: fine-tune end-to-end at low learning rate
 p2:


### PR DESCRIPTION
## Summary
- pass a pair directory to the P1 target

## Testing
- `python scripts/train_transformer.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python utils/build_pairs.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68662725442c83288c731ce956b2e16f