### PR TITLE
Fix duplicate makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,3 @@ p1:
 p2:
 	python scripts/finetune_end2end.py --lr 1e-5 $(ARGS)
 
-# Build EEG/video latent pairs
-pairs:
-	python utils/build_pairs.py \$(ARGS)


### PR DESCRIPTION
## Summary
- clean up Makefile by removing second `pairs` rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662eb912ac8328a664aec2ed943342