### PR TITLE
Adapt video latent extraction

### DIFF
--- a/EEG_preprocessing/extract_DE_PSD_features_1per2s.py
+++ b/EEG_preprocessing/extract_DE_PSD_features_1per2s.py
@@ -40,4 +40,4 @@ if __name__ == "__main__":
         np.save("./data/Preprocessing/PSD_1per2s/sub" + str(subname) + ".npy", PSD_data)
         print(f"Saved DE data in ./data/Preprocessing/DE_1per2s/sub{str(subname)}.npy")
         print(f"Saved PSD data in ./data/Preprocessing/PSD_1per2s/sub{str(subname)}.npy")
-        
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: p0 p1 p2 pairs
+.PHONY: p0 p1 p2 pairs video_latents
 
 
 # Pass additional options with ARGS
@@ -9,8 +9,12 @@ p0:
 
 # Build npz/torch latent pairs
 pairs:
-	python utils/build_pairs.py $(ARGS)
-	python utils/pairs_to_torch.py $(ARGS)
+        python utils/build_pairs.py $(ARGS)
+        python utils/pairs_to_torch.py $(ARGS)
+
+# Extract video latents organized by block
+video_latents:
+        python encoders/video_vae/extract_latents.py $(ARGS)
 
 # P1: train Transformer with VAE and diffusion frozen
 p1:


### PR DESCRIPTION
## Summary
- enable recursive extraction of video latents from block subfolders
- default `extract_latents.py` to `data/Video_mp4`
- add `video_latents` make target
- clean end of `extract_DE_PSD_features_1per2s.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866338e023c832880b335c5bcb68a24