### PR TITLE
Update build_pairs for sequential naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ Embeddings can also be produced with the features-only model using `EEGtoVideo/G
 Video clips are converted into 2-second GIFs and encoded with the VAE from Stable Diffusion. Each clip becomes a latent tensor stored alongside the EEG embeddings.
 
 ## 4. Pair Creation
-EEG embeddings and video latents share the same block/concept/repetition identifiers. Run `make pairs` to call `utils/build_pairs.py`, which aligns both sets of latents and writes `.npz` files to `data/latent_pairs/`.
+EEG embeddings are stored per subject under `subX/block/index.npy` where
+`index = 5 * concept + repetition` (200 files per block). Video latents share the
+same `block/index.npy` structure without the subject prefix. Run `make pairs` to
+call `utils/build_pairs.py`, which drops the subject level, aligns both sets of
+latents and writes `.npz` files to `data/latent_pairs/`.
 The optional helper `utils/pairs_to_torch.py` loads every archive from this directory,
 stacks the `eeg_latent` and `video_latent` arrays and saves them in a single
 `torch` file with the keys `src` and `tgt`.


### PR DESCRIPTION
## Summary
- clarify directory structure in README
- document sequential numbering in build_pairs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686662df21dc8328b706004395d73b3e