### PR TITLE
Fix npz support for video latents

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ Script: `EEGtoVideo/GLMNet/inference_glmnet.py`
 Embeddings can also be produced with the features-only model using `EEGtoVideo/GLMNet/inference_glfnet_mlp.py`.
 
 ## 3. Video Latent Extraction
-Video clips are converted into 2-second GIFs and encoded with the VAE from Stable Diffusion. Each clip becomes a latent tensor stored alongside the EEG embeddings.
+Video clips are converted into 2-second GIFs and encoded with the VAE from Stable Diffusion. Each clip becomes a latent tensor stored alongside the EEG embeddings. Latents are saved as `.npz` archives.
 
 ## 4. Pair Creation
 EEG embeddings are stored per subject under `subX/block/index.npy` where
 `index = 5 * concept + repetition` (200 files per block). Video latents share the
 same `block/index.npy` structure without the subject prefix. Run `make pairs` to
 call `utils/build_pairs.py`, which drops the subject level, aligns both sets of
-latents and writes `.npz` files to `data/latent_pairs/`.
+latents (from `.npy` or `.npz` files) and writes `.npz` files to `data/latent_pairs/`.
 The optional helper `utils/pairs_to_torch.py` loads every archive from this directory,
 stacks the `eeg_latent` and `video_latent` arrays and saves them in a single
 `torch` file with the keys `src` and `tgt`.

--- a/utils/align.py
+++ b/utils/align.py
@@ -6,6 +6,17 @@ __all__ = [
 ]
 
 
+def _load_latent(path: str) -> np.ndarray:
+    """Return latent array from ``path`` regardless of extension."""
+    data = np.load(path)
+    if isinstance(data, np.lib.npyio.NpzFile):
+        key = "latents" if "latents" in data else data.files[0]
+        arr = data[key]
+        data.close()
+        return arr
+    return data
+
+
 def load_aligned_latents(eeg_path: str, video_path: str):
     """Load EEG and video latents and align them by length.
 
@@ -21,8 +32,8 @@ def load_aligned_latents(eeg_path: str, video_path: str):
     tuple of np.ndarray
         Tuple `(eeg_latent, video_latent)` trimmed to the same number of samples.
     """
-    eeg_latent = np.load(eeg_path)
-    video_latent = np.load(video_path)
+    eeg_latent = _load_latent(eeg_path)
+    video_latent = _load_latent(video_path)
 
     n = min(len(eeg_latent), len(video_latent))
     return eeg_latent[:n], video_latent[:n]

--- a/utils/build_pairs.py
+++ b/utils/build_pairs.py
@@ -21,8 +21,9 @@ def build_pairs(eeg_dir: str, video_dir: str, output_dir: str) -> None:
         own folder ``subX`` with files organised as ``subX/block/index.npy``
         where ``index = 5 * concept + repetition``.
     video_dir : str
-        Directory with the corresponding video latents. The hierarchy mirrors the
-        EEG data but without the subject prefix, i.e. ``block/index.npy``.
+        Directory with the corresponding video latents (``.npy`` or ``.npz``).
+        The hierarchy mirrors the EEG data but without the subject prefix,
+        i.e. ``block/index.npy``.
     output_dir : str
         Where the paired ``.npz`` files will be written.
     """
@@ -44,8 +45,12 @@ def build_pairs(eeg_dir: str, video_dir: str, output_dir: str) -> None:
             video_rel = os.path.join(*parts[1:])
         video_path = os.path.join(video_dir, video_rel)
         if not os.path.exists(video_path):
-            print(f"Video latent missing for {video_rel}, skipping")
-            continue
+            alt = os.path.splitext(video_path)[0] + ".npz"
+            if os.path.exists(alt):
+                video_path = alt
+            else:
+                print(f"Video latent missing for {video_rel}, skipping")
+                continue
         out_path = os.path.join(output_dir, os.path.splitext(rel_path)[0] + ".npz")
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
 


### PR DESCRIPTION
## Summary
- support loading video latents stored as `.npz`
- document npz output in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867637d908c8328a100d18517bc1f74