### PR TITLE
Improve path docs for Block directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Embeddings can also be produced with the features-only model using `EEGtoVideo/G
 Video clips are converted into 2-second GIFs and encoded with the VAE from Stable Diffusion. Each clip becomes a latent tensor stored alongside the EEG embeddings. Latents are saved as `.npz` archives.
 
 ## 4. Pair Creation
-EEG embeddings are stored per subject under `subX/block/index.npy` where
-`index = 5 * concept + repetition` (200 files per block). Video latents share the
-same `block/index.npy` structure without the subject prefix. Run `make pairs` to
+EEG embeddings are stored per subject under `subX/Block{block}/index.npy` where
+`index = 5 * concept + repetition` (indices 1–200 per block). Video latents share the
+same `Block{block}/index.npy` structure without the subject prefix. Run `make pairs` to
 call `utils/build_pairs.py`, which drops the subject level, aligns both sets of
 latents (from `.npy` or `.npz` files) and writes `.npz` files to `data/latent_pairs/`.
 The optional helper `utils/pairs_to_torch.py` loads every archive from this directory,


### PR DESCRIPTION
## Résumé
- mettre à jour le README avec la structure `Block{block}`
- préciser la même structure dans le docstring de `build_pairs`

## Tests
- `python -m py_compile utils/build_pairs.py`


------
https://chatgpt.com/codex/tasks/task_e_6867669b14cc832896ea73813ecad272