### PR TITLE
Update diffusion model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The Transformer takes EEG embeddings as input and predicts the corresponding vid
 
 ## 6. Video Generation with Diffusion
 At inference time, the Transformer predicts a latent from unseen EEG signals. This latent is then decoded by Stable Diffusion to produce the final video.
+By default, all scripts load the diffusion weights from `hpcai-tech/Open-Sora-Plan-1.3`.
+You can override this with `--diffusion_weights` (or `--model` in `diffusion/generate.py`).
 
 # Further work
 Investigate on the reason why generated videos lack of contrast.

--- a/diffusion/generate.py
+++ b/diffusion/generate.py
@@ -32,7 +32,12 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate video from latent")
-    parser.add_argument("--model", type=str, default="open-sora/open_sora")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="hpcai-tech/Open-Sora-Plan-1.3",
+        help="Diffusion model checkpoint to load",
+    )
     parser.add_argument("--latent", type=str, required=True)
     parser.add_argument("--latent_dim", type=int, default=1024)
     parser.add_argument("--output", type=str, default="output.mp4")

--- a/diffusion/lora_tune.py
+++ b/diffusion/lora_tune.py
@@ -69,7 +69,7 @@ def add_lora(model, ratio=0.05):
 async def train(args):
     accelerator = Accelerator()
     pipe = DiffusionPipeline.from_pretrained(
-        "open-sora/open_sora", torch_dtype=torch.float16
+        args.diffusion_weights, torch_dtype=torch.float16
     )
     pipe.to(accelerator.device)
 
@@ -119,6 +119,12 @@ def parse_args():
     parser.add_argument("--output", type=str, required=True, help="Path to save LoRA")
     parser.add_argument("--steps", type=int, default=5000, help="Training steps")
     parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument(
+        "--diffusion_weights",
+        type=str,
+        default="hpcai-tech/Open-Sora-Plan-1.3",
+        help="Diffusion model checkpoint to load",
+    )
     return parser.parse_args()
 
 

--- a/scripts/finetune_end2end.py
+++ b/scripts/finetune_end2end.py
@@ -39,7 +39,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--lr", type=float, default=1e-5)
     p.add_argument("--save", type=Path, default=Path("finetuned.pt"))
     p.add_argument("--vae_weights", type=str, default="encoders/video_vae/vae.pt")
-    p.add_argument("--diffusion_weights", type=str, default="open-sora/open_sora")
+    p.add_argument(
+        "--diffusion_weights",
+        type=str,
+        default="hpcai-tech/Open-Sora-Plan-1.3",
+        help="Diffusion model checkpoint to load",
+    )
     p.add_argument("--ckpt", type=Path, default=None, help="pretrained transformer checkpoint")
     return p.parse_args()
 

--- a/scripts/train_transformer.py
+++ b/scripts/train_transformer.py
@@ -60,7 +60,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--freeze_vae", action="store_true")
     p.add_argument("--freeze_diffuser", action="store_true")
     p.add_argument("--vae_weights", type=str, default="encoders/video_vae/vae.pt")
-    p.add_argument("--diffusion_weights", type=str, default="open-sora/open_sora")
+    p.add_argument(
+        "--diffusion_weights",
+        type=str,
+        default="hpcai-tech/Open-Sora-Plan-1.3",
+        help="Diffusion model checkpoint to load",
+    )
     return p.parse_args()
 
 


### PR DESCRIPTION
## Summary
- set `--diffusion_weights` default to `hpcai-tech/Open-Sora-Plan-1.3`
- expose diffusion weights in `lora_tune.py`
- document diffusion model default in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6867c578a02083288c0adb4dbcb1c761