### PR TITLE
Mettre Open-Sora en local

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The Transformer takes EEG embeddings as input and predicts the corresponding vid
 
 ## 6. Video Generation with Diffusion
 At inference time, the Transformer predicts a latent from unseen EEG signals. This latent is then decoded by Stable Diffusion to produce the final video.
-By default, all scripts load the diffusion weights from `hpcai-tech/Open-Sora-Plan-1.3`.
+By default, all scripts load the diffusion weights from the local folder `Open-Sora-Plan-1.3`.
 You can override this with `--diffusion_weights` (or `--model` in `diffusion/generate.py`).
 
 # Further work

--- a/diffusion/generate.py
+++ b/diffusion/generate.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model",
         type=str,
-        default="hpcai-tech/Open-Sora-Plan-1.3",
+        default="Open-Sora-Plan-1.3",
         help="Diffusion model checkpoint to load",
     )
     parser.add_argument("--latent", type=str, required=True)

--- a/diffusion/lora_tune.py
+++ b/diffusion/lora_tune.py
@@ -122,7 +122,7 @@ def parse_args():
     parser.add_argument(
         "--diffusion_weights",
         type=str,
-        default="hpcai-tech/Open-Sora-Plan-1.3",
+        default="Open-Sora-Plan-1.3",
         help="Diffusion model checkpoint to load",
     )
     return parser.parse_args()

--- a/scripts/finetune_end2end.py
+++ b/scripts/finetune_end2end.py
@@ -42,7 +42,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--diffusion_weights",
         type=str,
-        default="hpcai-tech/Open-Sora-Plan-1.3",
+        default="Open-Sora-Plan-1.3",
         help="Diffusion model checkpoint to load",
     )
     p.add_argument("--ckpt", type=Path, default=None, help="pretrained transformer checkpoint")

--- a/scripts/train_transformer.py
+++ b/scripts/train_transformer.py
@@ -63,7 +63,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--diffusion_weights",
         type=str,
-        default="hpcai-tech/Open-Sora-Plan-1.3",
+        default="Open-Sora-Plan-1.3",
         help="Diffusion model checkpoint to load",
     )
     return p.parse_args()


### PR DESCRIPTION
## Résumé
- chargement par défaut d'Open-Sora depuis `Open-Sora-Plan-1.3`
- mise à jour de la documentation

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686b7396730c8328ba7a69fb9dc74e88