### PR TITLE
Ajout fichier label_mappings et documentation

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -1,0 +1,22 @@
+# GLMNet Utilities
+
+This directory contains scripts used to train and run the GLMNet EEG encoder.
+
+## Label mappings
+
+`label_mappings.json` stores textual descriptions for the integer labels used
+by various training categories. The file is a dictionary where each key is a
+category name (e.g. `color` or `label_cluster`) and each value is another
+dictionary mapping label IDs to their string description.
+
+Example structure:
+
+```json
+{
+  "color": {"0": "black and white", "1": "color"},
+  "label": {"1": "example label 1", "2": "example label 2"}
+}
+```
+
+`multi_inference.py` should load this JSON once and look up the description
+corresponding to the predicted label for each category.

--- a/EEGtoVideo/GLMNet/label_mappings.json
+++ b/EEGtoVideo/GLMNet/label_mappings.json
@@ -1,0 +1,30 @@
+{
+    "color": {
+        "0": "black and white",
+        "1": "color"
+    },
+    "face_appearance": {
+        "0": "no face visible",
+        "1": "face visible"
+    },
+    "human_appearance": {
+        "0": "no human",
+        "1": "human present"
+    },
+    "label": {
+        "1": "example label 1",
+        "2": "example label 2"
+    },
+    "label_cluster": {
+        "0": "cluster zero",
+        "1": "cluster one"
+    },
+    "obj_number": {
+        "0": "single object",
+        "1": "multiple objects"
+    },
+    "optical_flow_score": {
+        "0": "low motion",
+        "1": "high motion"
+    }
+}


### PR DESCRIPTION
## Résumé
- ajout d'un exemple de `label_mappings.json` pour GLMNet
- documentation du format dans `EEGtoVideo/GLMNet/README.md`

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e134ad5148328bad1e2874e571c58