### PR TITLE
Utiliser label_mappings dans multi_inference

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -18,5 +18,15 @@ Example structure:
 }
 ```
 
-`multi_inference.py` should load this JSON once and look up the description
-corresponding to the predicted label for each category.
+`multi_inference.py` loads this JSON and automatically maps the
+predicted class indices from each checkpoint to their textual
+descriptions.  The script infers the label category from the checkpoint
+directory name (everything after the first underscore).
+
+Example usage:
+
+```bash
+python multi_inference.py \
+  --eeg example.npy \
+  --checkpoint_dirs ckpt_color ckpt_face ckpt_human ckpt_label ckpt_obj_number
+```

--- a/EEGtoVideo/GLMNet/multi_inference.py
+++ b/EEGtoVideo/GLMNet/multi_inference.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 """Run multiple GLMNet models on a single EEG example.
 
-This script loads several GLMNet checkpoints together with their
-associated class mappings and predicts text labels for a provided EEG
-window. The five textual predictions are concatenated to form a phrase.
+This script loads five GLMNet checkpoints and converts their
+predictions into text using ``label_mappings.json``.  The textual
+outputs are concatenated to form a descriptive phrase.
 """
 
 import argparse
 import json
 import os
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 import torch
@@ -26,12 +26,14 @@ from EEGtoVideo.GLMNet.modules.models_paper import mlpnet
 
 OCCIPITAL_IDX = list(range(50, 62))
 
-
-def load_mapping(path: str) -> Dict[int, str]:
-    """Load a class mapping from a JSON file."""
+def load_label_mappings(path: str) -> Dict[str, Dict[int, str]]:
+    """Load textual descriptions for every label category."""
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    return {int(k): str(v) for k, v in data.items()}
+    mappings: Dict[str, Dict[int, str]] = {}
+    for cat, mapping in data.items():
+        mappings[cat] = {int(k): str(v) for k, v in mapping.items()}
+    return mappings
 
 
 def prepare_input(eeg: np.ndarray, stats, scaler) -> tuple[torch.Tensor, torch.Tensor]:
@@ -56,25 +58,56 @@ def load_model(ckpt_dir: str, channels: int, time_len: int, device: str) -> tupl
     return model, scaler, stats
 
 
-def predict_text(eeg: np.ndarray, models: List[GLMNet], scalers, stats_list, mappings, device: str) -> str:
+def get_category(path: str) -> str:
+    """Infer the label category from a checkpoint directory."""
+    name = os.path.basename(os.path.normpath(path))
+    parts = name.split("_")
+    if len(parts) < 2:
+        raise ValueError(f"Cannot infer category from '{name}'")
+    return "_".join(parts[1:])
+
+
+def index_to_text(category: str, idx: int, label_map: Dict[str, Dict[int, str]]) -> str:
+    """Convert predicted class index to textual description."""
+    if category in {"label", "obj_number"}:
+        idx += 1
+    return label_map.get(category, {}).get(idx, str(idx))
+
+
+def predict_text(
+    eeg: np.ndarray,
+    models: List[GLMNet],
+    scalers,
+    stats_list,
+    categories: List[str],
+    label_map: Dict[str, Dict[int, str]],
+    device: str,
+) -> str:
     """Generate a phrase by applying each model to the EEG sample."""
     parts = []
-    for mdl, scaler, stats, mapping in zip(models, scalers, stats_list, mappings):
+    for mdl, scaler, stats, cat in zip(models, scalers, stats_list, categories):
         x_raw, x_feat = prepare_input(eeg, stats, scaler)
         x_raw = x_raw.to(device)
         x_feat = x_feat.to(device)
         with torch.no_grad():
             logits = mdl(x_raw, x_feat)
             pred = int(logits.argmax(dim=-1).item())
-        parts.append(mapping.get(pred, str(pred)))
+        parts.append(index_to_text(cat, pred, label_map))
     return " ".join(parts)
 
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Run multiple GLMNet models on one EEG window")
     p.add_argument("--eeg", required=True, help="Path to EEG numpy file (C,T)")
-    p.add_argument("--checkpoint_dirs", nargs=5, required=True, help="Five GLMNet checkpoint directories")
-    p.add_argument("--mapping_files", nargs=5, required=True, help="JSON files mapping class indices to text")
+    p.add_argument(
+        "--checkpoint_dirs", nargs=5, required=True,
+        help="Five GLMNet checkpoint directories"
+    )
+    p.add_argument(
+        "--mapping_path",
+        default=os.path.join(os.path.dirname(__file__), "label_mappings.json"),
+        help="Path to label_mappings.json"
+    )
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
@@ -90,9 +123,18 @@ def main() -> None:
         scalers.append(scaler)
         stats_list.append(stats)
 
-    mappings = [load_mapping(p) for p in args.mapping_files]
+    label_map = load_label_mappings(args.mapping_path)
+    categories = [get_category(c) for c in args.checkpoint_dirs]
 
-    phrase = predict_text(eeg, models, scalers, stats_list, mappings, args.device)
+    phrase = predict_text(
+        eeg,
+        models,
+        scalers,
+        stats_list,
+        categories,
+        label_map,
+        args.device,
+    )
     print(phrase)
 
 


### PR DESCRIPTION
## Résumé
- mise à jour de `multi_inference.py` pour charger `label_mappings.json`
- ajout d'une logique de conversion d'indices selon la catégorie
- adaptation de l'interface CLI et documentation

## Tests
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e258b1f58832897e11d3165c1db9f