### PR TITLE
Ajout de paramètres d'index pour multi_inference

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -28,5 +28,9 @@ Example usage:
 ```bash
 python multi_inference.py \
   --eeg example.npy \
+  --concept 0 --repetition 0 --window 0 \
   --checkpoint_dirs ckpt_color ckpt_face ckpt_human ckpt_label ckpt_obj_number
 ```
+
+The `--concept`, `--repetition` and `--window` arguments select which slice of a
+multi-dimensional EEG array to process. They default to `0` if omitted.

--- a/EEGtoVideo/GLMNet/multi_inference.py
+++ b/EEGtoVideo/GLMNet/multi_inference.py
@@ -98,7 +98,10 @@ def predict_text(
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Run multiple GLMNet models on one EEG window")
-    p.add_argument("--eeg", required=True, help="Path to EEG numpy file (C,T)")
+    p.add_argument("--eeg", required=True, help="Path to EEG numpy file (concept, repetition, window, C, T)")
+    p.add_argument("--concept", type=int, default=0, help="Concept index to load")
+    p.add_argument("--repetition", type=int, default=0, help="Repetition index to load")
+    p.add_argument("--window", type=int, default=0, help="Window index to load")
     p.add_argument(
         "--checkpoint_dirs", nargs=5, required=True,
         help="Five GLMNet checkpoint directories"
@@ -111,7 +114,8 @@ def main() -> None:
     p.add_argument("--device", default="cpu")
     args = p.parse_args()
 
-    eeg = np.load(args.eeg)
+    eeg_all = np.load(args.eeg)
+    eeg = eeg_all[args.concept, args.repetition, args.window]
     channels, time_len = eeg.shape
 
     models = []


### PR DESCRIPTION
## Résumé
- ajout des arguments `--concept`, `--repetition` et `--window` dans `multi_inference.py`
- sélection de la tranche EEG correspondante lors du chargement
- mise à jour de la documentation avec un exemple utilisant ces nouveaux paramètres

## Tests
- `python -m py_compile EEGtoVideo/GLMNet/multi_inference.py`


------
https://chatgpt.com/codex/tasks/task_e_687e27de7934832885c699b851fb074f