### PR TITLE
Improve GLMNet multi-window inference

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -28,9 +28,10 @@ Example usage:
 ```bash
 python multi_inference.py \
   --eeg example.npy \
-  --concept 0 --repetition 0 --window 0 \
+  --concept 0 --repetition 0 \
   --checkpoint_dirs ckpt_color ckpt_face ckpt_human ckpt_label ckpt_obj_number
 ```
 
-The `--concept`, `--repetition` and `--window` arguments select which slice of a
-multi-dimensional EEG array to process. They default to `0` if omitted.
+The script now evaluates all seven windows corresponding to the selected
+`concept` and `repetition`.  For each model the label occurring most
+often across the windows is kept and a confidence score is reported.


### PR DESCRIPTION
## Summary
- compute GLMNet predictions across all windows and keep the most frequent label
- report a confidence score for each label
- update CLI and docs accordingly

## Testing
- `python -m py_compile EEGtoVideo/GLMNet/multi_inference.py`
- `python -m py_compile EEGtoVideo/GLMNet/*.py EEGtoVideo/GLMNet/modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687f129f79208328bbdac0155b7d3175