### PR TITLE
Add color_binary category

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -34,3 +34,10 @@ python multi_inference.py \
 
 The `--concept`, `--repetition` and `--window` arguments select which slice of a
 multi-dimensional EEG array to process. They default to `0` if omitted.
+
+## Binary color category
+
+`color_binary` is a simplified version of the original `color` labels. It maps
+any label other than `0` to the value `1`, indicating that one color dominates
+the image. Label `0` still represents videos with many colors. Use
+`--category color_binary` when training to enable this behaviour.

--- a/EEGtoVideo/GLMNet/label_mappings.json
+++ b/EEGtoVideo/GLMNet/label_mappings.json
@@ -8,6 +8,10 @@
         "5": "white",
         "6": "gray"
     },
+    "color_binary": {
+        "0": "many colors",
+        "1": "dominant color"
+    },
     "face_appearance": {
         "0": "no face visible",
         "1": "face visible"

--- a/EEGtoVideo/GLMNet/train_glmnet.py
+++ b/EEGtoVideo/GLMNet/train_glmnet.py
@@ -43,7 +43,21 @@ def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument("--raw_dir",  default="./data/Preprocessing/Segmented_500ms_sw", help="directory with .npy files")
     p.add_argument("--label_dir", default="./data/meta_info", help="Label file")
-    p.add_argument("--category", default="label_cluster",choices=['color', 'face_appearance', 'human_appearance','label_cluster','label','obj_number','optical_flow_score'], help="Label file")
+    p.add_argument(
+        "--category",
+        default="label_cluster",
+        choices=[
+            "color",
+            "color_binary",
+            "face_appearance",
+            "human_appearance",
+            "label_cluster",
+            "label",
+            "obj_number",
+            "optical_flow_score",
+        ],
+        help="Label file",
+    )
     p.add_argument("--save_dir", default="./EEGtoVideo/checkpoints/glmnet")
     p.add_argument("--epochs",   type=int, default=500)
     p.add_argument("--bs",       type=int, default=100)
@@ -73,6 +87,9 @@ def format_labels(labels: np.ndarray, category:str) -> np.ndarray:
     match category:
         case "color" | "face_appearance" | "human_appearance" | "label_cluster":
             return labels.astype(np.int64)
+        case "color_binary":
+            # Collapse all non-zero colors into the dominant color class
+            return (labels != 0).astype(np.int64)
         case "label" | "obj_number" :
             labels = labels-1
             return labels.astype(np.int64)
@@ -80,7 +97,9 @@ def format_labels(labels: np.ndarray, category:str) -> np.ndarray:
             threshold = 1.799
             return (labels > threshold).astype(np.int64)
         case _:
-            raise ValueError(f"Unknown category: {category}. Must be one of: color, face_appearance, human_appearance, object, label_cluster, label, obj_number, optical_flow_score.")
+            raise ValueError(
+                f"Unknown category: {category}. Must be one of: color, color_binary, face_appearance, human_appearance, object, label_cluster, label, obj_number, optical_flow_score."
+            )
 # ------------------------------ main -------------------------------------
 def main():
     args = parse_args()


### PR DESCRIPTION
## Summary
- add `color_binary` choice to GLMNet training script
- collapse color labels to binary in `format_labels`
- extend label mapping with `color_binary`
- document the new category in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f133b1d548328b8b2a38921a9e9c0