### PR TITLE
Add fallback for color_binary labels

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -41,5 +41,8 @@ often across the windows is kept and a confidence score is reported.
 `color_binary` is a simplified version of the original `color` labels. It maps
 any label other than `0` to the value `1`, indicating that one color dominates
 the image. Label `0` still represents videos with many colors. Use
-`--category color_binary` when training to enable this behaviour.
+`--category color_binary` when training to enable this behaviour. If a file
+named `All_video_color_binary.npy` is not present in `--label_dir`, the training
+script falls back to `All_video_color.npy` and performs the conversion at
+runtime.
 

--- a/EEGtoVideo/GLMNet/train_glmnet.py
+++ b/EEGtoVideo/GLMNet/train_glmnet.py
@@ -122,7 +122,11 @@ def main():
         raw.reshape(-1, raw.shape[-2], raw.shape[-1])
     ).reshape(*raw.shape[:4], raw.shape[-2], -1)
     
-    labels_raw = np.load(f'{args.label_dir}/All_video_{args.category}.npy')                       # (7,40)
+    label_path = os.path.join(args.label_dir, f"All_video_{args.category}.npy")
+    if args.category == "color_binary" and not os.path.exists(label_path):
+        # Fallback to the multi-class color labels and binarize later
+        label_path = os.path.join(args.label_dir, "All_video_color.npy")
+    labels_raw = np.load(label_path)  # expected shape: (7, 40)
     unique_labels, counts_labels = np.unique(labels_raw, return_counts=True)
     label_distribution = {int(u): int(c) for u, c in zip(unique_labels, counts_labels)}
     print("Label distribution:", label_distribution)


### PR DESCRIPTION
## Summary
- adjust `train_glmnet.py` so `color_binary` falls back to `All_video_color.npy` when the binary file is missing
- document the fallback in `GLMNet/README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1a2c97dc832886b02a830335eeab