### PR TITLE
Handle new color labels

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -43,3 +43,7 @@ any label other than `0` to the value `1`, indicating that one color dominates
 the image. Label `0` still represents videos with many colors. Use
 `--category color_binary` when training to enable this behaviour.
 
+When training with `--category color`, samples tagged as `0` are discarded and
+the remaining color IDs (1-6) are shifted down to 0-5.  `label_mappings.json`
+lists the updated names for these six classes.
+

--- a/EEGtoVideo/GLMNet/label_mappings.json
+++ b/EEGtoVideo/GLMNet/label_mappings.json
@@ -1,12 +1,11 @@
 {
     "color": {
-        "0": "many colors",
-        "1": "red",
-        "2": "green",
-        "3": "blue",
-        "4": "yellow",
-        "5": "white",
-        "6": "gray"
+        "0": "red",
+        "1": "green",
+        "2": "blue",
+        "3": "yellow",
+        "4": "white",
+        "5": "gray"
     },
     "color_binary": {
         "0": "many colors",


### PR DESCRIPTION
## Summary
- filter out label `0` from the color dataset in `train_glmnet.py`
- shift remaining color IDs to 0..5
- generalize label reshaping and update label formatting
- adjust color mapping file for the six classes
- document the new behavior in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f1a71a81c8328b641c7aaab91a6c8