### PR TITLE
Add cluster filter option for GLMNet

### DIFF
--- a/EEGtoVideo/GLMNet/README.md
+++ b/EEGtoVideo/GLMNet/README.md
@@ -50,3 +50,11 @@ When training with `--category color`, samples tagged as `0` are discarded and
 the remaining color IDs (1-6) are shifted down to 0-5.  `label_mappings.json`
 lists the updated names for these six classes.
 
+## Cluster-specific label training
+
+For the `label` category you can focus on a single label cluster by passing
+`--cluster <idx>` to `train_glmnet.py`. The script loads
+`All_video_label_cluster.npy` from `--label_dir` and filters the dataset to the
+selected cluster before training.  Within that subset, the original label IDs
+are remapped to a contiguous range starting at zero.
+


### PR DESCRIPTION
## Summary
- allow training GLMNet on one label cluster via new `--cluster` argument
- adjust checkpoint naming and wandb runs when filtering by cluster
- mask videos by cluster and remap labels to a contiguous range
- document cluster-specific training in README

## Testing
- `python -m py_compile EEGtoVideo/GLMNet/train_glmnet.py`
- `black EEGtoVideo/GLMNet/train_glmnet.py --line-length 120`


------
https://chatgpt.com/codex/tasks/task_e_687f51e030f88328a4e8e041a3e03751