### PR TITLE
Ajout de la sélection manuelle des sujets pour GLMNet

### DIFF
--- a/GLMNet/README.md
+++ b/GLMNet/README.md
@@ -61,3 +61,19 @@ For the `label` category you can focus on a single label cluster by passing
 selected cluster before training.  Within that subset, the original label IDs
 are remapped to a contiguous range starting at zero.
 
+## Manual subject selection
+
+`train_glmnet.py` normally picks subjects at random. You can override this
+behaviour by specifying the exact subjects for each split using
+`--train_subjects`, `--val_subjects` and `--test_subjects`.  Each option accepts
+a list of file basenames without the `.npy` extension. If you only provide the
+training subjects, the script randomly chooses two validation subjects from the
+remaining pool and assigns the rest to the test set.
+
+Example:
+
+```bash
+python train_glmnet.py --train_subjects sub01 sub02 sub03 \
+  --val_subjects sub04 sub05 --category color
+```
+

--- a/GLMNet/train_glmnet.py
+++ b/GLMNet/train_glmnet.py
@@ -72,7 +72,22 @@ def parse_args():
         help="Type of learning rate scheduler",
     )
     p.add_argument("--use_wandb", action="store_true")
-    p.add_argument("--n_subj", type=int, default=15, help="Number of subjects to sample for train/val")
+    p.add_argument(
+        "--train_subjects",
+        nargs="+",
+        help="List of subjects to use for training (without extension)",
+    )
+    p.add_argument(
+        "--val_subjects",
+        nargs="+",
+        help="List of subjects to use for validation (without extension)",
+    )
+    p.add_argument(
+        "--test_subjects",
+        nargs="+",
+        help="List of subjects to use for testing (without extension)",
+    )
+    p.add_argument("--n_subj", type=int, default=15, help="Number of subjects to sample for train/val when not provided")
     p.add_argument("--seed", type=int, default=0, help="Random seed for subject sampling")
     return p.parse_args()
 
@@ -122,13 +137,40 @@ def main():
     all_subj = sorted(
         f[:-4] for f in os.listdir(args.raw_dir) if f.startswith("sub") and f.endswith(".npy")
     )
-    if args.n_subj > len(all_subj):
-        raise ValueError("Not enough subject files in raw_dir")
-    rng.shuffle(all_subj)
-    selected = all_subj[: args.n_subj]
-    train_subj = selected[:13]
-    val_subj = selected[13:15]
-    test_subj = [s for s in all_subj if s not in selected]
+
+    def check_exists(names: list[str], where: list[str]) -> None:
+        missing = [n for n in names if n not in where]
+        if missing:
+            raise ValueError(f"Subject files not found: {missing}")
+
+    if args.train_subjects:
+        check_exists(args.train_subjects, all_subj)
+        train_subj = list(args.train_subjects)
+        remaining = [s for s in all_subj if s not in train_subj]
+    else:
+        if args.n_subj > len(all_subj):
+            raise ValueError("Not enough subject files in raw_dir")
+        rng.shuffle(all_subj)
+        selected = all_subj[: args.n_subj]
+        train_subj = selected[:13]
+        remaining = [s for s in all_subj if s not in train_subj]
+
+    if args.val_subjects:
+        check_exists(args.val_subjects, remaining)
+        val_subj = list(args.val_subjects)
+        remaining = [s for s in remaining if s not in val_subj]
+    else:
+        if len(remaining) < 2:
+            raise ValueError("Not enough subjects available for validation")
+        rng.shuffle(remaining)
+        val_subj = remaining[:2]
+        remaining = remaining[2:]
+
+    if args.test_subjects:
+        check_exists(args.test_subjects, all_subj)
+        test_subj = list(args.test_subjects)
+    else:
+        test_subj = remaining
 
     print("Training subjects:", train_subj)
     print("Validation subjects:", val_subj)


### PR DESCRIPTION
## Résumé
- permettre de choisir directement les sujets de train/val/test dans `train_glmnet.py`
- documenter l'option dans `README.md`

## Tests
- `python -m py_compile GLMNet/train_glmnet.py`
- `python -m py_compile GLMNet/multi_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6881f168ff548328b8ab9c19ab794b72