### PR TITLE
Ajout d'un cache de features pour GLMNet

### DIFF
--- a/GLMNet/README.md
+++ b/GLMNet/README.md
@@ -77,3 +77,10 @@ python train_glmnet.py --train_subjects sub01 sub02 sub03 \
   --val_subjects sub04 sub05 --category color
 ```
 
+## Feature caching
+
+Computing spectral features for every subject can be slow.
+You can pass `--cache_dir <path>` to `train_glmnet.py` to reuse features across runs.
+The script will save features as `<path>/<subject>_feat.npy` after the first computation
+and load them on subsequent executions.
+

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ WANDB_ARG := $(if $(use_wandb),--use_wandb)
 
 # Directory for checkpoints
 CKPT_ROOT := GLMNet/checkpoints
+CACHE_DIR := GLMNet/cache
 
 # Default training subjects used when calling ``make``
 TRAIN_SUBJECTS := sub13 sub9 sub15 sub11 sub3 sub6 sub12 sub2 sub19 sub17 sub1 sub20 sub16
@@ -27,16 +28,16 @@ checkpoints:
 	@set -e; \
 	for c in $(CATEGORIES); do \
 			ckpt="$(CKPT_ROOT)/$(SUB_DIR)/$$c/glmnet_best.pt"; \
-			if [ ! -f $$ckpt ]; then \
-					$(PYTHON) $(TRAIN_SCRIPT) --category $$c --train_subjects $(TRAIN_SUBJECTS) $(WANDB_ARG); \
+                       if [ ! -f $$ckpt ]; then \
+                                       $(PYTHON) $(TRAIN_SCRIPT) --category $$c --train_subjects $(TRAIN_SUBJECTS) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
 			else \
 					echo "[Makefile] Skip $$c: checkpoint already exists"; \
 			fi; \
 	done; \
 	for cl in $(LABEL_CLUSTERS); do \
 			ckpt="$(CKPT_ROOT)/$(SUB_DIR)/label_cluster$$cl/glmnet_best.pt"; \
-			if [ ! -f $$ckpt ]; then \
-					$(PYTHON) $(TRAIN_SCRIPT) --category label --cluster $$cl --train_subjects $(TRAIN_SUBJECTS) $(WANDB_ARG); \
+                       if [ ! -f $$ckpt ]; then \
+                                       $(PYTHON) $(TRAIN_SCRIPT) --category label --cluster $$cl --train_subjects $(TRAIN_SUBJECTS) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
 			else \
 					echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
 			fi; \


### PR DESCRIPTION
## Résumé
- ajoute l'option `--cache_dir` dans `train_glmnet.py`
- charge et sauvegarde les features pré‑calculés
- documente le mécanisme de cache dans `GLMNet/README.md`
- met à jour le Makefile pour utiliser ce cache

## Tests
- `python -m py_compile GLMNet/train_glmnet.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6881fb0357a083288a38f660869dfd5b