### PR TITLE
Add multi-sample support in multi_inference

### DIFF
--- a/GLMNet/README.md
+++ b/GLMNet/README.md
@@ -28,12 +28,14 @@ Example usage:
 ```bash
 python multi_inference.py \
   --eeg example.npy \
-  --concept 0 --repetition 0 \
+  --concepts 0 1 \
+  --repetitions 0 1 \
+  --blocks 0 1 \
   --checkpoint_root ./EEGtoVideo/checkpoints/glmnet/sub3
 ```
 
-The script now evaluates all seven windows corresponding to the selected
-`concept` and `repetition`.  For each model the label occurring most
+The script now evaluates all seven windows for every combination of the
+selected `blocks`, `concepts` and `repetitions`. For each model the label occurring most
 often across the windows is kept and a confidence score is reported.
 The individual texts are then merged into a single sentence of the form
 `A <cluster> which is a <label>, ...`. This phrasing can be used directly


### PR DESCRIPTION
## Summary
- allow `multi_inference.py` to process multiple blocks, concepts and repetitions
- update README with new CLI usage

## Testing
- `python -m py_compile GLMNet/multi_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6886720ab9ec83288630896238e05fd1