### PR TITLE
Fix cluster label mapping for train_net

### DIFF
--- a/GLMNet/train_net.py
+++ b/GLMNet/train_net.py
@@ -187,6 +187,14 @@ def main():
 
     base_labels = format_labels(expand_labels_flat(labels_flat, n_win), args.category)
 
+    if args.cluster is not None and args.category == "label":
+        uniq = np.sort(np.unique(base_labels))
+        mapping = {v: i for i, v in enumerate(uniq)}
+        base_labels = np.vectorize(mapping.get)(base_labels)
+        print(
+            f"Cluster {args.cluster}: mapping original labels {uniq.tolist()} -> {list(mapping.values())}"
+        )
+
     unique_labels, counts_labels = np.unique(base_labels, return_counts=True)
     num_unique_labels = len(unique_labels)
     label_final_distribution = {int(u): int(c) for u, c in zip(unique_labels, counts_labels)}


### PR DESCRIPTION
## Summary
- map labels to contiguous range when training on a filtered label cluster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886d03d1908328a93e1a4e1f3e1b47