### PR TITLE
Simplification de la sélection de sujets

### DIFF
--- a/GLMNet/train_glmnet.py
+++ b/GLMNet/train_glmnet.py
@@ -72,21 +72,6 @@ def parse_args():
         help="Type of learning rate scheduler",
     )
     p.add_argument("--use_wandb", action="store_true")
-    p.add_argument(
-        "--train_subjects",
-        nargs="+",
-        help="List of subjects to use for training (without extension)",
-    )
-    p.add_argument(
-        "--val_subjects",
-        nargs="+",
-        help="List of subjects to use for validation (without extension)",
-    )
-    p.add_argument(
-        "--test_subjects",
-        nargs="+",
-        help="List of subjects to use for testing (without extension)",
-    )
     p.add_argument("--n_subj", type=int, default=15, help="Number of subjects to sample for train/val when not provided")
     p.add_argument("--seed", type=int, default=0, help="Random seed for subject sampling")
     p.add_argument(
@@ -144,39 +129,15 @@ def main():
         f[:-4] for f in os.listdir(args.raw_dir) if f.startswith("sub") and f.endswith(".npy")
     )
 
-    def check_exists(names: list[str], where: list[str]) -> None:
-        missing = [n for n in names if n not in where]
-        if missing:
-            raise ValueError(f"Subject files not found: {missing}")
+    if args.n_subj > len(all_subj):
+        raise ValueError("Not enough subject files in raw_dir")
 
-    if args.train_subjects:
-        check_exists(args.train_subjects, all_subj)
-        train_subj = list(args.train_subjects)
-        remaining = [s for s in all_subj if s not in train_subj]
-    else:
-        if args.n_subj > len(all_subj):
-            raise ValueError("Not enough subject files in raw_dir")
-        rng.shuffle(all_subj)
-        selected = all_subj[: args.n_subj]
-        train_subj = selected[:13]
-        remaining = [s for s in all_subj if s not in train_subj]
-
-    if args.val_subjects:
-        check_exists(args.val_subjects, remaining)
-        val_subj = list(args.val_subjects)
-        remaining = [s for s in remaining if s not in val_subj]
-    else:
-        if len(remaining) < 2:
-            raise ValueError("Not enough subjects available for validation")
-        rng.shuffle(remaining)
-        val_subj = remaining[:2]
-        remaining = remaining[2:]
-
-    if args.test_subjects:
-        check_exists(args.test_subjects, all_subj)
-        test_subj = list(args.test_subjects)
-    else:
-        test_subj = remaining
+    rng.shuffle(all_subj)
+    selected = all_subj[: args.n_subj]
+    # first subjects are used for training and validation, the rest form the test set
+    train_subj = selected[:13]
+    val_subj = selected[13:15]
+    test_subj = [s for s in all_subj if s not in train_subj and s not in val_subj]
 
     print("Training subjects:", train_subj)
     print("Validation subjects:", val_subj)

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ CACHE_DIR := GLMNet/cache
 CKPT_ROOT_NET := GLMNet/checkpoints_net
 TRAIN_NET_SCRIPT := GLMNet/train_net.py
 
-# Default training subjects used when calling ``make``
-TRAIN_SUBJECTS := sub13 sub9 sub15 sub11 sub3 sub6 sub12 sub2 sub19 sub17 sub1 sub20 sub16
+# Directory name matching the default split with seed 0
 SUB_DIR := sub_13_9_15_11_3_6_12_2_19_17_1_20_16
 
 .PHONY: checkpoints
@@ -32,16 +31,16 @@ checkpoints:
 	@set -e; \
 	for c in $(CATEGORIES); do \
 			ckpt="$(CKPT_ROOT)/$(SUB_DIR)/$$c/glmnet_best.pt"; \
-		       if [ ! -f $$ckpt ]; then \
-				       $(PYTHON) $(TRAIN_SCRIPT) --category $$c --train_subjects $(TRAIN_SUBJECTS) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
+                       if [ ! -f $$ckpt ]; then \
+                                       $(PYTHON) $(TRAIN_SCRIPT) --category $$c --seed $(SPLIT_SEED) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
 			else \
 					echo "[Makefile] Skip $$c: checkpoint already exists"; \
 			fi; \
 	done; \
 	for cl in $(LABEL_CLUSTERS); do \
 			ckpt="$(CKPT_ROOT)/$(SUB_DIR)/label_cluster$$cl/glmnet_best.pt"; \
-		       if [ ! -f $$ckpt ]; then \
-				       $(PYTHON) $(TRAIN_SCRIPT) --category label --cluster $$cl --train_subjects $(TRAIN_SUBJECTS) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
+                       if [ ! -f $$ckpt ]; then \
+                                       $(PYTHON) $(TRAIN_SCRIPT) --category label --cluster $$cl --seed $(SPLIT_SEED) --cache_dir $(CACHE_DIR) $(WANDB_ARG); \
 			else \
 					echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
 			fi; \
@@ -64,16 +63,16 @@ checkpoints_net:
 	@set -e; \
 	for c in $(CATEGORIES); do \
 		ckpt="$(CKPT_ROOT_NET)/$(SUB_DIR)/$$c/$(MODEL)_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_NET_SCRIPT) --category $$c --model $(MODEL) --train_subjects $(TRAIN_SUBJECTS) $(WANDB_ARG); \
+                if [ ! -f $$ckpt ]; then \
+                        $(PYTHON) $(TRAIN_NET_SCRIPT) --category $$c --model $(MODEL) --seed $(SPLIT_SEED) $(WANDB_ARG); \
 		else \
 			echo "[Makefile] Skip $$c: checkpoint already exists"; \
 		fi; \
 	done; \
 	for cl in $(LABEL_CLUSTERS); do \
 		ckpt="$(CKPT_ROOT_NET)/$(SUB_DIR)/label_cluster$$cl/$(MODEL)_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_NET_SCRIPT) --category label --cluster $$cl --model $(MODEL) --train_subjects $(TRAIN_SUBJECTS) $(WANDB_ARG); \
+                if [ ! -f $$ckpt ]; then \
+                        $(PYTHON) $(TRAIN_NET_SCRIPT) --category label --cluster $$cl --model $(MODEL) --seed $(SPLIT_SEED) $(WANDB_ARG); \
 		else \
 			echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
 		fi; \


### PR DESCRIPTION
## Résumé
- enlever la gestion des listes de sujets dans `train_glmnet.py`
- idem dans `train_net.py`
- ajuster le Makefile pour utiliser `--seed 0`

## Tests
- `python -m py_compile GLMNet/train_glmnet.py GLMNet/train_net.py`
- `flake8` n'a pas pu être installé à cause des restrictions réseau

------
https://chatgpt.com/codex/tasks/task_e_6889adf300fc8328b678d060cd22d6b7