### PR TITLE
Load GLMNet checkpoints with torch.load

### DIFF
--- a/GLMNet/inference_glmnet.py
+++ b/GLMNet/inference_glmnet.py
@@ -80,9 +80,12 @@ def generate_all_embeddings(
         # expect shape: (7, 40, 5, 7, 62, T)
         time_len = RAW_SW.shape[-1]
         num_channels = RAW_SW.shape[-2]
-        model = GLMNet.load_from_checkpoint(
-            model_path, OCCIPITAL_IDX, C = num_channels, T= time_len, device=device
-        )
+        state = torch.load(model_path, map_location=device)
+        out_dim = GLMNet.infer_out_dim(state)
+        model = GLMNet(OCCIPITAL_IDX, C=num_channels, T=time_len, out_dim=out_dim)
+        model.load_state_dict(state)
+        model.to(device)
+        model.eval()
         embeddings = inf_glmnet(model, scaler, RAW_SW, stats, device)
         
         out_path = os.path.join(output_dir, f"{subj}.npy")

--- a/GLMNet/multi_inference.py
+++ b/GLMNet/multi_inference.py
@@ -69,9 +69,12 @@ def load_model(ckpt_dir: str, channels: int, time_len: int, device: str) -> tupl
     scaler = load_scaler(os.path.join(ckpt_dir, "scaler.pkl"))
     stats = load_raw_stats(os.path.join(ckpt_dir, "raw_stats.npz"))
     model_path = os.path.join(ckpt_dir, "glmnet_best.pt")
-    model = GLMNet.load_from_checkpoint(
-        model_path, OCCIPITAL_IDX, C=channels, T=time_len, device=device
-    )
+    state = torch.load(model_path, map_location=device)
+    out_dim = GLMNet.infer_out_dim(state)
+    model = GLMNet(OCCIPITAL_IDX, C=channels, T=time_len, out_dim=out_dim)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
     return model, scaler, stats
 
 def index_to_text(

--- a/GLMNet/train_glmnet.py
+++ b/GLMNet/train_glmnet.py
@@ -373,7 +373,12 @@ def main():
                 }
             )
 
-    model = GLMNet.load_from_checkpoint(glmnet_path, OCCIPITAL_IDX, num_channels, time_len, device=device)
+    state = torch.load(glmnet_path, map_location=device)
+    out_dim = GLMNet.infer_out_dim(state)
+    model = GLMNet(OCCIPITAL_IDX, C=num_channels, T=time_len, out_dim=out_dim)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
     test_acc = 0
     preds, labels_test = [], []
     with torch.no_grad():

--- a/GLMNet/train_glmnet_1sub.py
+++ b/GLMNet/train_glmnet_1sub.py
@@ -342,7 +342,12 @@ def main():
                 }
             )
 
-    model = GLMNet.load_from_checkpoint(glmnet_path, OCCIPITAL_IDX, num_channels, time_len, device=device)
+    state = torch.load(glmnet_path, map_location=device)
+    out_dim = GLMNet.infer_out_dim(state)
+    model = GLMNet(OCCIPITAL_IDX, C=num_channels, T=time_len, out_dim=out_dim)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
 
     scaler = load_scaler(scaler_path)
     raw_mean, raw_std = load_raw_stats(stats_path)

--- a/GLMNet/train_glmnet_1sub_shuffle.py
+++ b/GLMNet/train_glmnet_1sub_shuffle.py
@@ -323,7 +323,12 @@ def main():
                 }
             )
 
-    model = GLMNet.load_from_checkpoint(glmnet_path, OCCIPITAL_IDX, num_channels, time_len, device=device)
+    state = torch.load(glmnet_path, map_location=device)
+    out_dim = GLMNet.infer_out_dim(state)
+    model = GLMNet(OCCIPITAL_IDX, C=num_channels, T=time_len, out_dim=out_dim)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
 
     scaler = load_scaler(scaler_path)
     raw_mean, raw_std = load_raw_stats(stats_path)


### PR DESCRIPTION
## Résumé
- remplacement des appels à `GLMNet.load_from_checkpoint` par `torch.load`
- précision dans la docstring de `load_from_checkpoint`

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889c19300008328b1a3f9803dd22627