### PR TITLE
Fix mono checkpoint path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 wandb/
 data/
 checkpoints*/
+Checkpoints/
 __pycache__/
 
 # Files types

--- a/Classifiers/README.md
+++ b/Classifiers/README.md
@@ -20,8 +20,8 @@ Example structure:
 
 `multi_inference.py` loads this JSON and automatically maps the
 predicted class indices from each checkpoint to their textual
-descriptions.  The script infers the label category from the checkpoint
-directory name (everything after the first underscore).
+descriptions.  The script infers the label category from the final directory
+name of each checkpoint path.
 
 Example usage:
 
@@ -31,7 +31,7 @@ python multi_inference.py \
   --concepts 0 1 \
   --repetitions 0 1 \
   --blocks 0 1 \
-  --checkpoint_root ./EEGtoVideo/checkpoints/glmnet/sub3
+  --checkpoint_root ./Checkpoints/multi/0/glmnet
 ```
 
 The script now evaluates all seven windows for every combination of the

--- a/Classifiers/inference_glmnet.py
+++ b/Classifiers/inference_glmnet.py
@@ -98,11 +98,21 @@ if __name__ == "__main__":
     parser.add_argument('--raw_dir', default="./data/Preprocessing/Segmented_500ms_sw", help='directory of pre-windowed raw EEG .npy files')
     parser.add_argument('--subject_prefix', default='sub3', help='prefix of subject files to process')
     parser.add_argument('--checkpoint_path', help='path to GLMNet checkpoint')
+    parser.add_argument('--train_mode', choices=['ordered', 'shuffle'], default='ordered', help='training mode for mono model')
+    parser.add_argument('--seed', type=int, default=0, help='Training seed')
     parser.add_argument('--output_dir', default="./data/eeg_segments", help='where to save projected embeddings')
     args = parser.parse_args()
 
     if args.checkpoint_path is None:
-        args.checkpoint_path = f"./EEGtoVideo/checkpoints/glmnet/{args.subject_prefix}_label_cluster"
+        args.checkpoint_path = os.path.join(
+            "./Checkpoints",
+            "mono",
+            args.subject_prefix,
+            args.train_mode,
+            str(args.seed),
+            "glmnet",
+            "label_cluster",
+        )
 
     generate_all_embeddings(
         args.raw_dir,

--- a/Classifiers/train_glmnet.py
+++ b/Classifiers/train_glmnet.py
@@ -50,7 +50,7 @@ def parse_args():
         ],
         help="Label file",
     )
-    p.add_argument("--save_dir", default="./Classifiers/checkpoints/")
+    p.add_argument("--save_dir", default="./Checkpoints")
     p.add_argument(
         "--cluster",
         type=int,
@@ -131,7 +131,13 @@ def main():
     ckpt_name = args.category
     if args.cluster is not None:
         ckpt_name += f"_cluster{args.cluster}"
-    ckpt_dir = os.path.join(args.save_dir, f"sub_{name_ids}", ckpt_name)
+    ckpt_dir = os.path.join(
+        args.save_dir,
+        "multi",
+        str(args.seed),
+        "glmnet",
+        ckpt_name,
+    )
     os.makedirs(ckpt_dir, exist_ok=True)
     glmnet_path = os.path.join(ckpt_dir, "glmnet_best.pt")
     stats_path = os.path.join(ckpt_dir, "raw_stats.npz")

--- a/Classifiers/train_glmnet_1sub.py
+++ b/Classifiers/train_glmnet_1sub.py
@@ -50,7 +50,7 @@ def parse_args():
         ],
         help="Label file",
     )
-    p.add_argument("--save_dir", default="./Classifiers/checkpoints/")
+    p.add_argument("--save_dir", default="./Checkpoints")
     p.add_argument(
         "--cluster",
         type=int,
@@ -108,7 +108,15 @@ def main():
     ckpt_name = args.category
     if args.cluster is not None:
         ckpt_name += f"_cluster{args.cluster}"
-    ckpt_dir = os.path.join(args.save_dir, args.subj_name, ckpt_name)
+    ckpt_dir = os.path.join(
+        args.save_dir,
+        "mono",
+        args.subj_name,
+        "ordered",
+        str(args.split_seed),
+        "glmnet",
+        ckpt_name,
+    )
     os.makedirs(ckpt_dir, exist_ok=True)
     shallownet_path = os.path.join(ckpt_dir, "shallownet.pt")
     mlpnet_path = os.path.join(ckpt_dir, "mlpnet.pt")

--- a/Classifiers/train_glmnet_1sub_shuffle.py
+++ b/Classifiers/train_glmnet_1sub_shuffle.py
@@ -50,7 +50,7 @@ def parse_args():
         ],
         help="Label file",
     )
-    p.add_argument("--save_dir", default="./Classifiers/checkpoints/")
+    p.add_argument("--save_dir", default="./Checkpoints")
     p.add_argument(
         "--cluster",
         type=int,
@@ -69,6 +69,7 @@ def parse_args():
     )
     p.add_argument("--use_wandb", action="store_true")
     p.add_argument("--subj_name", default="sub3", help="Subject name to process")
+    p.add_argument("--seed", type=int, default=0, help="Random seed")
     return p.parse_args()
 
 def format_labels(labels: np.ndarray, category: str) -> np.ndarray:
@@ -102,7 +103,15 @@ def main():
     ckpt_name = args.category
     if args.cluster is not None:
         ckpt_name += f"_cluster{args.cluster}"
-    ckpt_dir = os.path.join(args.save_dir, args.subj_name, ckpt_name)
+    ckpt_dir = os.path.join(
+        args.save_dir,
+        "mono",
+        args.subj_name,
+        "shuffle",
+        str(args.seed),
+        "glmnet",
+        ckpt_name,
+    )
     os.makedirs(ckpt_dir, exist_ok=True)
     shallownet_path = os.path.join(ckpt_dir, "shallownet.pt")
     mlpnet_path = os.path.join(ckpt_dir, "mlpnet.pt")

--- a/Classifiers/train_net.py
+++ b/Classifiers/train_net.py
@@ -42,7 +42,7 @@ def parse_args():
         ],
         help="Label file",
     )
-    p.add_argument("--save_dir", default="./Classifiers/checkpoints_net/")
+    p.add_argument("--save_dir", default="./Checkpoints")
     p.add_argument(
         "--cluster",
         type=int,
@@ -117,7 +117,13 @@ def main():
     ckpt_name = args.category
     if args.cluster is not None:
         ckpt_name += f"_cluster{args.cluster}"
-    ckpt_dir = os.path.join(args.save_dir, f"sub_{name_ids}", ckpt_name)
+    ckpt_dir = os.path.join(
+        args.save_dir,
+        "multi",
+        str(args.seed),
+        args.model,
+        ckpt_name,
+    )
     os.makedirs(ckpt_dir, exist_ok=True)
     model_path = os.path.join(ckpt_dir, f"{args.model}_best.pt")
     stats_path = os.path.join(ckpt_dir, "raw_stats.npz")

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ MODEL ?= deepnet
 SPLIT_SEED ?= 0
 
 # Directory for checkpoints
-CKPT_ROOT := Classifiers/checkpoints
+CKPT_ROOT := Checkpoints
 CACHE_DIR := Classifiers/cache
-CKPT_ROOT_NET := Classifiers/checkpoints_net
+CKPT_ROOT_NET := Checkpoints
 TRAIN_NET_SCRIPT := Classifiers/train_net.py
 
 # Directory name matching the default split with seed 0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ time)`.
 
 Any of the supported encoders can be trained on these windows.  Models predict
 class labels for categories such as *color*, *label cluster* or *object number*.
-Checkpoints are saved under directories named after their label categories.
+Checkpoints are stored under `Checkpoints/<mode>/<seed>/<model>/<category>`.
+For single-subject runs the hierarchy becomes
+`Checkpoints/mono/<subject>/<ordered|shuffle>/<seed>/<model>/<category>`.
 
 ## Classification and text generation
 
@@ -47,7 +49,7 @@ python Classifiers/multi_inference.py \
   --blocks 0 1 \
   --concepts 0 1 \
   --repetitions 0 1 \
-  --checkpoint_root ./checkpoints/glmnet/sub3
+  --checkpoint_root ./Checkpoints/multi/0/glmnet
 ```
 
 The script evaluates all windows for every selected segment and prints the


### PR DESCRIPTION
## Summary
- ajustement des dossiers mono : ajout du niveau `ordered` ou `shuffle`
- option `--train_mode` pour le script d'inférence mono
- documentation mise à jour avec la nouvelle hiérarchie

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6889d8eedc048328b95c578c81a3bcbf