### PR TITLE
Ajout utilitaire de split par seed

### DIFF
--- a/Classifiers/modules/utils.py
+++ b/Classifiers/modules/utils.py
@@ -1,6 +1,7 @@
 from sklearn.preprocessing import StandardScaler
 import numpy as np
 import pickle
+import os
 
 def standard_scale_features(X, scaler=None, return_scaler=False):
     """Scale features with ``StandardScaler``.
@@ -58,3 +59,95 @@ def load_raw_stats(path: str) -> tuple[np.ndarray, np.ndarray]:
     """Load raw EEG normalization statistics from a ``.npz`` file."""
     data = np.load(path)
     return data["mean"], data["std"]
+
+
+def subject_split(
+    seed: int,
+    subjects: list[str],
+    ckpt_seed_dir: str,
+    n_select: int | None = None,
+    n_train: int = 13,
+    n_val: int = 2,
+) -> tuple[list[str], list[str], list[str]]:
+    """Deterministically split subjects for multi-subject training.
+
+    Parameters
+    ----------
+    seed : int
+        Seed controlling the shuffle.
+    subjects : list[str]
+        Available subject names.
+    ckpt_seed_dir : str
+        Directory where ``subjects.txt`` will be written.
+    n_select : int, optional
+        Number of subjects drawn from ``subjects`` before splitting.
+        If ``None`` all subjects are considered.
+    n_train : int, optional
+        Number of subjects used for training.
+    n_val : int, optional
+        Number of subjects used for validation.
+
+    Returns
+    -------
+    tuple[list[str], list[str], list[str]]
+        Lists of train, validation and test subjects.
+    """
+
+    rng = np.random.default_rng(seed)
+    subj_sorted = sorted(subjects)
+    rng.shuffle(subj_sorted)
+
+    if n_select is not None:
+        if n_select > len(subj_sorted):
+            raise ValueError("Not enough subjects to select")
+        selected = subj_sorted[:n_select]
+    else:
+        selected = subj_sorted
+
+    if n_train + n_val > len(selected):
+        raise ValueError("Not enough subjects to split")
+
+    train_subj = selected[:n_train]
+    val_subj = selected[n_train : n_train + n_val]
+    test_subj = [s for s in subj_sorted if s not in train_subj and s not in val_subj]
+
+    os.makedirs(ckpt_seed_dir, exist_ok=True)
+    txt_path = os.path.join(ckpt_seed_dir, "subjects.txt")
+    if not os.path.exists(txt_path):
+        with open(txt_path, "w") as f:
+            f.write("train:" + ",".join(train_subj) + "\n")
+            f.write("val:" + ",".join(val_subj) + "\n")
+            f.write("test:" + ",".join(test_subj) + "\n")
+
+    return train_subj, val_subj, test_subj
+
+
+def block_split(seed: int, n_blocks: int, ckpt_seed_dir: str) -> tuple[int, int]:
+    """Choose validation and test blocks for single-subject training.
+
+    Parameters
+    ----------
+    seed : int
+        Seed controlling the selection.
+    n_blocks : int
+        Total number of blocks in the data.
+    ckpt_seed_dir : str
+        Directory where ``blocks.txt`` will be written.
+
+    Returns
+    -------
+    tuple[int, int]
+        Selected validation and test block indices.
+    """
+
+    rng = np.random.RandomState(seed)
+    val_block, test_block = rng.choice(np.arange(n_blocks), size=2, replace=False)
+
+    os.makedirs(ckpt_seed_dir, exist_ok=True)
+    txt_path = os.path.join(ckpt_seed_dir, "blocks.txt")
+    if not os.path.exists(txt_path):
+        with open(txt_path, "w") as f:
+            f.write(f"val:{int(val_block)}\n")
+            f.write(f"test:{int(test_block)}\n")
+
+    return int(val_block), int(test_block)

--- a/Classifiers/train_glmnet_1sub.py
+++ b/Classifiers/train_glmnet_1sub.py
@@ -19,6 +19,7 @@ from Classifiers.modules.utils import (
     standard_scale_features,
     compute_raw_stats,
     normalize_raw,
+    block_split,
 )
 from Classifiers.modules.models import mlpnet, glmnet
 
@@ -200,8 +201,14 @@ def main():
 
     block_ids_win = np.repeat(block_ids, n_win)
 
-    rng = np.random.RandomState(args.split_seed)
-    val_block, test_block = rng.choice(np.arange(n_blocks), size=2, replace=False)
+    ckpt_seed_dir = os.path.join(
+        args.save_dir,
+        "mono",
+        args.subj_name,
+        "ordered",
+        str(args.split_seed),
+    )
+    val_block, test_block = block_split(args.split_seed, n_blocks, ckpt_seed_dir)
     print(f"Validation block: {val_block}, Test block: {test_block}")
 
     train_mask = (block_ids_win != val_block) & (block_ids_win != test_block)

--- a/Classifiers/train_net.py
+++ b/Classifiers/train_net.py
@@ -13,7 +13,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from Classifiers.modules.utils import compute_raw_stats, normalize_raw
+from Classifiers.modules.utils import compute_raw_stats, normalize_raw, subject_split
 from Classifiers.modules.models import deepnet, eegnet
 
 
@@ -93,7 +93,6 @@ def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"Using device: {device}")
 
-    rng = np.random.default_rng(args.seed)
     all_subj = sorted(
         f[:-4] for f in os.listdir(args.raw_dir) if f.startswith("sub") and f.endswith(".npy")
     )
@@ -101,12 +100,13 @@ def main():
     if args.n_subj > len(all_subj):
         raise ValueError("Not enough subject files in raw_dir")
 
-    rng.shuffle(all_subj)
-    selected = all_subj[: args.n_subj]
-    # first subjects are used for training and validation, the rest form the test set
-    train_subj = selected[:13]
-    val_subj = selected[13:15]
-    test_subj = [s for s in all_subj if s not in train_subj and s not in val_subj]
+    ckpt_seed_dir = os.path.join(args.save_dir, "multi", str(args.seed))
+    train_subj, val_subj, test_subj = subject_split(
+        args.seed,
+        all_subj,
+        ckpt_seed_dir=ckpt_seed_dir,
+        n_select=args.n_subj,
+    )
 
     print("Training subjects:", train_subj)
     print("Validation subjects:", val_subj)


### PR DESCRIPTION
## Résumé
- ajout de `subject_split` et `block_split` dans `utils.py`
- écriture des splits dans des fichiers texte au niveau du seed
- utilisation de ces fonctions dans les scripts d'entraînement multi et mono sujet

## Tests
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889e0a825fc8328b408d95e72e742a3