### PR TITLE
Update Makefile for mono/multi checkpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@
 # Default Python interpreter
 PYTHON ?= python
 
-# Training script relative path
-TRAIN_SCRIPT := Classifiers/train_glmnet.py
+# Training scripts used for training
+TRAIN_MULTI_SCRIPT := Classifiers/train_classifier_multi.py
+TRAIN_MONO_SCRIPT  := Classifiers/train_classifier_mono.py
 
 # Categories excluding raw label which is trained per cluster
 CATEGORIES := color color_binary face_appearance human_appearance label_cluster obj_number optical_flow_score
@@ -13,73 +14,56 @@ CATEGORIES := color color_binary face_appearance human_appearance label_cluster 
 LABEL_CLUSTERS := 0 1 2 3 4 5 6 7 8
 
 # Optional argument to enable wandb logging
-WANDB_ARG := $(if $(use_wandb),--use_wandb)
-MODEL ?= deepnet
-SPLIT_SEED ?= 0
+WANDB_ARG   := $(if $(use_wandb),--use_wandb)
+MODEL ?= glmnet
+SEED  ?= 0
+SUBJECT ?= sub3
+# Flag to shuffle mono training instead of ordered mode
+SHUFFLE_ARG := $(if $(shuffle),--shuffle)
+MODE := $(if $(shuffle),shuffle,ordered)
 
 # Directory for checkpoints
 CKPT_ROOT := Classifiers/checkpoints
-TRAIN_NET_SCRIPT := Classifiers/train_net.py
 
 
-.PHONY: checkpoints
-checkpoints:
-	@set -e; \
-	for c in $(CATEGORIES); do \
-		ckpt="$(CKPT_ROOT)/multi/$(SPLIT_SEED)/glmnet/$$c/glmnet_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_SCRIPT) --category $$c --seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
-		else \
-			echo "[Makefile] Skip $$c: checkpoint already exists"; \
-		fi; \
-	done; \
-	for cl in $(LABEL_CLUSTERS); do \
-		ckpt="$(CKPT_ROOT)/multi/$(SPLIT_SEED)/glmnet/label_cluster$$cl/glmnet_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_SCRIPT) --category label --cluster $$cl --seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
-		else \
-			echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
-		fi; \
-	done
+# Train checkpoints for the multi-subject setup
+.PHONY: checkpoints_multi
+checkpoints_multi:
+       @set -e; \
+       for c in $(CATEGORIES); do \
+               ckpt="$(CKPT_ROOT)/multi/$(SEED)/$(MODEL)/$$c/$(MODEL)_best.pt"; \
+               if [ ! -f $$ckpt ]; then \
+                       $(PYTHON) $(TRAIN_MULTI_SCRIPT) --category $$c --model $(MODEL) --seed $(SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
+               else \
+                       echo "[Makefile] Skip $$c: checkpoint already exists"; \
+               fi; \
+       done; \
+       for cl in $(LABEL_CLUSTERS); do \
+               ckpt="$(CKPT_ROOT)/multi/$(SEED)/$(MODEL)/label_cluster$$cl/$(MODEL)_best.pt"; \
+               if [ ! -f $$ckpt ]; then \
+                       $(PYTHON) $(TRAIN_MULTI_SCRIPT) --category label --cluster $$cl --model $(MODEL) --seed $(SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
+               else \
+                       echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
+               fi; \
+       done
 
-TRAIN_1SUB_SCRIPT := Classifiers/train_glmnet_1sub.py
-SUBJECT_TO_TRAIN := sub3
-.PHONY: checkpoints_1sub
-checkpoints_1sub:
-	@set -e; \
-	for c in $(CATEGORIES); do \
-		ckpt="$(CKPT_ROOT)/mono/$(SUBJECT_TO_TRAIN)/ordered/$(SPLIT_SEED)/glmnet/$$c/glmnet_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_1SUB_SCRIPT) --category $$c $(WANDB_ARG) --subj_name $(SUBJECT_TO_TRAIN) --split_seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT); \
-		else \
-			echo "[Makefile] Skip $$c: checkpoint already exists"; \
-		fi; \
-	done; \
-	for cl in $(LABEL_CLUSTERS); do \
-		ckpt="$(CKPT_ROOT)/mono/$(SUBJECT_TO_TRAIN)/ordered/$(SPLIT_SEED)/glmnet/label_cluster$$cl/glmnet_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_1SUB_SCRIPT) --category label --cluster $$cl $(WANDB_ARG) --subj_name $(SUBJECT_TO_TRAIN) --split_seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT); \
-		else \
-			echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
-		fi; \
-	done
-
-.PHONY: checkpoints_net
-checkpoints_net:
-	@set -e; \
-	for c in $(CATEGORIES); do \
-		ckpt="$(CKPT_ROOT)/multi/$(SPLIT_SEED)/$(MODEL)/$$c/$(MODEL)_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_NET_SCRIPT) --category $$c --model $(MODEL) --seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
-		else \
-			echo "[Makefile] Skip $$c: checkpoint already exists"; \
-		fi; \
-	done; \
-	for cl in $(LABEL_CLUSTERS); do \
-		ckpt="$(CKPT_ROOT)/multi/$(SPLIT_SEED)/$(MODEL)/label_cluster$$cl/$(MODEL)_best.pt"; \
-		if [ ! -f $$ckpt ]; then \
-			$(PYTHON) $(TRAIN_NET_SCRIPT) --category label --cluster $$cl --model $(MODEL) --seed $(SPLIT_SEED) --save_dir $(CKPT_ROOT) $(WANDB_ARG); \
-		else \
-			echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
-		fi; \
-	done
+# Train checkpoints for the mono-subject setup
+.PHONY: checkpoints_mono
+checkpoints_mono:
+       @set -e; \
+       for c in $(CATEGORIES); do \
+               ckpt="$(CKPT_ROOT)/mono/$(SUBJECT)/$(MODE)/seed$(SEED)/$(MODEL)/$$c/$(MODEL)_best.pt"; \
+               if [ ! -f $$ckpt ]; then \
+                       $(PYTHON) $(TRAIN_MONO_SCRIPT) --category $$c --model $(MODEL) --seed $(SEED) --subj_name $(SUBJECT) --save_dir $(CKPT_ROOT) $(SHUFFLE_ARG) $(WANDB_ARG); \
+               else \
+                       echo "[Makefile] Skip $$c: checkpoint already exists"; \
+               fi; \
+       done; \
+       for cl in $(LABEL_CLUSTERS); do \
+               ckpt="$(CKPT_ROOT)/mono/$(SUBJECT)/$(MODE)/seed$(SEED)/$(MODEL)/label_cluster$$cl/$(MODEL)_best.pt"; \
+               if [ ! -f $$ckpt ]; then \
+                       $(PYTHON) $(TRAIN_MONO_SCRIPT) --category label --cluster $$cl --model $(MODEL) --seed $(SEED) --subj_name $(SUBJECT) --save_dir $(CKPT_ROOT) $(SHUFFLE_ARG) $(WANDB_ARG); \
+               else \
+                       echo "[Makefile] Skip label cluster $$cl: checkpoint already exists"; \
+               fi; \
+       done

--- a/README.md
+++ b/README.md
@@ -20,9 +20,19 @@ time)`.
 
 Any of the supported encoders can be trained on these windows.  Models predict
 class labels for categories such as *color*, *label cluster* or *object number*.
-Checkpoints are stored under `Checkpoints/<mode>/<seed>/<model>/<category>`.
+Checkpoints are stored under `Classifiers/checkpoints/<mode>/<seed>/<model>/<category>`.
 For single-subject runs the hierarchy becomes
-`Checkpoints/mono/<subject>/<ordered|shuffle>/<seed>/<model>/<category>`.
+`Classifiers/checkpoints/mono/<subject>/<ordered|shuffle>/seed<seed>/<model>/<category>`.
+
+Training across all categories can be automated with the Makefile:
+
+```bash
+# Multi-subject
+make checkpoints_multi SEED=0 MODEL=glmnet use_wandb=1
+
+# Mono-subject (ordered or shuffle)
+make checkpoints_mono SUBJECT=sub3 SEED=0 MODEL=glmnet shuffle=1
+```
 
 ## Classification and text generation
 


### PR DESCRIPTION
## Summary
- rewrite Makefile to train either multi or mono checkpoints
- allow passing model, seed and wandb parameters
- add shuffle option for mono training
- document Makefile usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a4a2b677483289e84169115f5fdcb