### PR TITLE
Update inference scripts for EEGNet and DeepNet

### DIFF
--- a/Classifiers/README.md
+++ b/Classifiers/README.md
@@ -21,7 +21,8 @@ Example structure:
 `multi_inference.py` loads this JSON and automatically maps the
 predicted class indices from each checkpoint to their textual
 descriptions.  The script infers the label category from the final directory
-name of each checkpoint path.
+name of each checkpoint path. Any of the supported models can be chosen via
+``--model``.
 
 Example usage:
 
@@ -31,7 +32,8 @@ python multi_inference.py \
   --concepts 0 1 \
   --repetitions 0 1 \
   --blocks 0 1 \
-  --checkpoint_root ./Classifiers/checkpoints/multi/0/glmnet
+  --checkpoint_root ./Classifiers/checkpoints/multi/0/deepnet \
+  --model deepnet
 ```
 
 The script now evaluates all seven windows for every combination of the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ selected model.  Predictions from the seven windows are combined using a
 majority vote to obtain one label per category.  The script
 `Classifiers/multi_inference.py` loads multiple checkpoints, performs this voting
 procedure and maps the predicted indices to text via
-`label_mappings.json`.  The individual pieces are merged into a single English
+`label_mappings.json`.  Any of the supported models (``glmnet``, ``eegnet`` or ``deepnet``)
+can be selected with ``--model``. The individual pieces are merged into a single English
 phrase like:
 
 ```
@@ -49,7 +50,8 @@ python Classifiers/multi_inference.py \
   --blocks 0 1 \
   --concepts 0 1 \
   --repetitions 0 1 \
-  --checkpoint_root ./Classifiers/checkpoints/multi/0/glmnet
+  --checkpoint_root ./Classifiers/checkpoints/multi/0/eegnet \
+  --model eegnet
 ```
 
 The script evaluates all windows for every selected segment and prints the


### PR DESCRIPTION
## Summary
- add `--model` option to inference scripts
- support EEGNet and DeepNet checkpoints
- document the new behaviour in READMEs

## Testing
- `python -m py_compile Classifiers/inference.py Classifiers/multi_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_688a49b17dc08328b7f38f263acc2699