### PR TITLE
Improve inference feature dimension handling

### DIFF
--- a/Classifiers/README.md
+++ b/Classifiers/README.md
@@ -23,6 +23,8 @@ predicted class indices from each checkpoint to their textual
 descriptions.  The script infers the label category from the final directory
 name of each checkpoint path. Any of the supported models can be chosen via
 ``--model``.
+The ``glmnet`` model automatically infers the feature dimension from the
+checkpoint so no additional argument is required.
 
 Example usage:
 

--- a/Classifiers/inference.py
+++ b/Classifiers/inference.py
@@ -83,7 +83,14 @@ def generate_all_embeddings(
         state = torch.load(model_path, map_location=device)
         if model_type == "glmnet":
             out_dim = glmnet.infer_out_dim(state)
-            model = glmnet(OCCIPITAL_IDX, C=num_channels, T=time_len, out_dim=out_dim)
+            feat_dim = glmnet.infer_feat_dim(state, len(OCCIPITAL_IDX))
+            model = glmnet(
+                OCCIPITAL_IDX,
+                C=num_channels,
+                T=time_len,
+                feat_dim=feat_dim,
+                out_dim=out_dim,
+            )
         else:
             out_dim = state["out.weight"].shape[0]
             model_cls = eegnet if model_type == "eegnet" else deepnet

--- a/Classifiers/modules/models.py
+++ b/Classifiers/modules/models.py
@@ -187,6 +187,18 @@ class glmnet(nn.Module):
             return state["fc.weight"].shape[0]
         raise KeyError("Cannot infer output dimension from checkpoint")
 
+    @staticmethod
+    def infer_feat_dim(state: dict, occipital_len: int) -> int:
+        """Infer ``feat_dim`` from a checkpoint state dict."""
+        for key in (
+            "freq_local.net.1.weight",
+            "module.freq_local.net.1.weight",
+        ):
+            if key in state:
+                in_features = state[key].shape[1]
+                return in_features // occipital_len
+        raise KeyError("Cannot infer feature dimension from checkpoint")
+
     def forward(self, x, return_features: bool = False):
         """Forward pass of the network.
 

--- a/Classifiers/multi_inference.py
+++ b/Classifiers/multi_inference.py
@@ -76,7 +76,14 @@ def load_model(
         model_path = os.path.join(ckpt_dir, "glmnet_best.pt")
         state = torch.load(model_path, map_location=device)
         out_dim = glmnet.infer_out_dim(state)
-        model = glmnet(OCCIPITAL_IDX, C=channels, T=time_len, out_dim=out_dim)
+        feat_dim = glmnet.infer_feat_dim(state, len(OCCIPITAL_IDX))
+        model = glmnet(
+            OCCIPITAL_IDX,
+            C=channels,
+            T=time_len,
+            feat_dim=feat_dim,
+            out_dim=out_dim,
+        )
     else:
         scaler = None
         model_path = os.path.join(ckpt_dir, f"{model_type}_best.pt")


### PR DESCRIPTION
## Summary
- infer the GLMNet feature dimension from checkpoints
- use the inferred feature dimension when loading models
- document automatic feature inference

## Testing
- `python -m py_compile Classifiers/inference.py Classifiers/multi_inference.py Classifiers/modules/models.py`

------
https://chatgpt.com/codex/tasks/task_e_688a4f87b69c8328b866cb93c06fb845