### PR TITLE
Improve window length validation in inference scripts

### DIFF
--- a/Classifiers/inference.py
+++ b/Classifiers/inference.py
@@ -82,6 +82,11 @@ def generate_all_embeddings(
         num_channels = RAW_SW.shape[-2]
         state = torch.load(model_path, map_location=device)
         if model_type == "glmnet":
+            ckpt_time_len = glmnet.infer_time_len(state)
+            if ckpt_time_len != time_len:
+                raise ValueError(
+                    f"EEG window length {time_len} does not match checkpoint (expected {ckpt_time_len})."
+                )
             out_dim = glmnet.infer_out_dim(state)
             feat_dim = glmnet.infer_feat_dim(state, len(OCCIPITAL_IDX))
             model = glmnet(

--- a/Classifiers/modules/models.py
+++ b/Classifiers/modules/models.py
@@ -199,6 +199,19 @@ class glmnet(nn.Module):
                 return in_features // occipital_len
         raise KeyError("Cannot infer feature dimension from checkpoint")
 
+    @staticmethod
+    def infer_time_len(state: dict) -> int:
+        """Infer ``T`` (window length) from a checkpoint state dict."""
+        for key in (
+            "raw_global.out.weight",
+            "module.raw_global.out.weight",
+        ):
+            if key in state:
+                in_features = state[key].shape[1]
+                n_samples = in_features // 40
+                return (n_samples - 1) * 5 + 75
+        raise KeyError("Cannot infer time length from checkpoint")
+
     def forward(self, x, return_features: bool = False):
         """Forward pass of the network.
 

--- a/Classifiers/multi_inference.py
+++ b/Classifiers/multi_inference.py
@@ -75,6 +75,11 @@ def load_model(
         scaler = load_scaler(os.path.join(ckpt_dir, "scaler.pkl"))
         model_path = os.path.join(ckpt_dir, "glmnet_best.pt")
         state = torch.load(model_path, map_location=device)
+        ckpt_time_len = glmnet.infer_time_len(state)
+        if ckpt_time_len != time_len:
+            raise ValueError(
+                f"EEG window length {time_len} does not match checkpoint (expected {ckpt_time_len})."
+            )
         out_dim = glmnet.infer_out_dim(state)
         feat_dim = glmnet.infer_feat_dim(state, len(OCCIPITAL_IDX))
         model = glmnet(

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ samples we apply a sliding‑window strategy with
 windows of 500 ms with an overlap of 250 ms.
 The resulting tensor has shape `(block, concept, repetition, window, channels,
 time)`.
+The checkpoints provided in this repository were trained using these 500 ms
+windows. Running inference on segments with a different duration, such as the
+`Segmented_1000ms_sw` dataset, will result in size mismatches.
 
 ## Training
 


### PR DESCRIPTION
## Summary
- add GLMNet helper to read expected window length from checkpoint
- validate EEG time length before loading checkpoints
- document that provided checkpoints use 500 ms windows

## Testing
- `python -m py_compile Classifiers/modules/models.py Classifiers/inference.py Classifiers/multi_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_688a5267c37883288af9034d9ffe91d2